### PR TITLE
Pass CODECOV token to upload action

### DIFF
--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -36,6 +36,8 @@ jobs:
 
       - name: Upload coverage
         uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   lint:
     name: Lint


### PR DESCRIPTION
This was a breaking change in the codecov/codecov-action@v4 action.