### PR TITLE
Fix RST escaping; add whitespace postprocessing for RST and MD

### DIFF
--- a/changelogs/fragments/296-postprocess.yml
+++ b/changelogs/fragments/296-postprocess.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - "Apply postprocessing to RST and MarkDown to avoid generating invalid markup when input contains whitespace at potentially dangerous places (https://github.com/ansible-community/antsibull-docs-ts/pull/296)."
+bugfixes:
+  - "Fix RST escaping to handle other whitespace than spaces correctly (https://github.com/ansible-community/antsibull-docs-ts/pull/296)."

--- a/src/md.spec.ts
+++ b/src/md.spec.ts
@@ -4,7 +4,7 @@
   SPDX-License-Identifier: BSD-2-Clause
 */
 
-import { quoteMD, toMD } from './md';
+import { quoteMD, toMD, postprocessMDParagraph } from './md';
 import { PartType } from './dom';
 
 describe('quoteMD tests', (): void => {
@@ -18,6 +18,15 @@ describe('quoteMD tests', (): void => {
     expect(quoteMD('[]!.()-\\@<>?[]!.()-\\@<>?&')).toBe(
       '\\[\\]\\!\\.\\(\\)\\-\\\\\\@\\<\\>\\?\\[\\]\\!\\.\\(\\)\\-\\\\\\@\\<\\>\\?\\&',
     );
+  });
+});
+
+describe('postprocessMDParagraph tests', (): void => {
+  it('empty string', (): void => {
+    expect(postprocessMDParagraph('')).toBe('');
+  });
+  it('string with some whitespace', (): void => {
+    expect(postprocessMDParagraph(' \n foo \n\r\n \n\tbar \n ')).toBe('foo\nbar');
   });
 });
 

--- a/src/md.ts
+++ b/src/md.ts
@@ -10,9 +10,17 @@ import { MDOptions, AllFormatOptions, mergeOpts } from './opts';
 import { OptionNamePart, Paragraph, ReturnValuePart } from './dom';
 import { quoteHTMLArg } from './html';
 import { addToDestination } from './format';
+import { splitLines } from './util';
 
 export function quoteMD(text: string): string {
   return text.replace(/([!"#$%&'()*+,:;<=>?@[\\\]^_`{|}~.-])/g, '\\$1');
+}
+
+export function postprocessMDParagraph(par: string): string {
+  return splitLines(par.trim())
+    .map((line) => line.trim().replace('\t', ' '))
+    .filter(Boolean)
+    .join('\n');
 }
 
 function formatOptionLike(
@@ -68,10 +76,8 @@ export function toMD(paragraphs: Paragraph[], opts?: MDOptions): string {
   for (const paragraph of paragraphs) {
     const line: string[] = [];
     addToDestination(line, paragraph, mergedOpts);
-    if (!line.length) {
-      line.push(' ');
-    }
-    result.push(line.join(''));
+    const lineStr = postprocessMDParagraph(line.join(''));
+    result.push(lineStr || ' ');
   }
   return result.join('\n\n');
 }

--- a/src/rst.spec.ts
+++ b/src/rst.spec.ts
@@ -4,7 +4,7 @@
   SPDX-License-Identifier: BSD-2-Clause
 */
 
-import { quoteRST, toRST } from './rst';
+import { quoteRST, toRST, postprocessRSTParagraph } from './rst';
 import { PartType } from './dom';
 
 describe('quoteRST tests', (): void => {
@@ -28,6 +28,30 @@ describe('quoteRST tests', (): void => {
   });
   it('more complex', (): void => {
     expect(quoteRST('\\<_>`*<_>*`\\')).toBe('\\\\\\<\\_\\>\\`\\*\\<\\_\\>\\*\\`\\\\');
+  });
+});
+
+describe('postprocessRSTParagraph tests', (): void => {
+  it('empty string', (): void => {
+    expect(postprocessRSTParagraph('')).toBe('');
+  });
+  it('string with some whitespace', (): void => {
+    expect(postprocessRSTParagraph(' \n foo \n\r\n \n\tbar \n ')).toBe('foo\nbar');
+  });
+  it('iteratively collapsing whitespace and escaped spaces', (): void => {
+    expect(postprocessRSTParagraph('\\ foo\\  \\  bar \\  \\ \n\nf\\ oo')).toBe('foo  bar\nf\\ oo');
+  });
+  it('collapsing multiple escaped spaces', (): void => {
+    expect(postprocessRSTParagraph('a\\ \\ \\ \\ \\ b')).toBe('a\\ b');
+  });
+  it('iteratively collapsing whitespace and escaped spaces at end of line', (): void => {
+    expect(postprocessRSTParagraph('a\\ \\  \\ \\    \\ \\  ')).toBe('a');
+  });
+  it('iteratively collapsing whitespace and escaped spaces at start of line', (): void => {
+    expect(postprocessRSTParagraph('\\ \\  \\ \\    \\ \\  a')).toBe('a');
+  });
+  it('iteratively collapsing whitespace and escaped spaces composing the line', (): void => {
+    expect(postprocessRSTParagraph('\\ \\  \\ \\    \\ \\  ')).toBe('');
   });
 });
 

--- a/src/rst.ts
+++ b/src/rst.ts
@@ -7,6 +7,7 @@
 import { RSTOptions, AllFormatOptions, mergeOpts } from './opts';
 import { OptionNamePart, Paragraph, ReturnValuePart } from './dom';
 import { addToDestination } from './format';
+import { splitLines, startsWith, endsWith } from './util';
 
 export function quoteRST(
   text: string,
@@ -16,16 +17,118 @@ export function quoteRST(
 ): string {
   text = text.replace(/([\\<>_*`])/g, '\\$1');
 
-  if (escape_ending_whitespace && text.endsWith(' ')) {
+  if (escape_ending_whitespace && /\s$/.test(text.substring(text.length - 1))) {
     text = text + '\\ ';
   }
-  if (escape_starting_whitespace && text.startsWith(' ')) {
+  if (escape_starting_whitespace && /^\s/.test(text)) {
     text = '\\ ' + text;
   }
   if (must_not_be_empty && text === '') {
     text = '\\ ';
   }
   return text;
+}
+
+function removeBackslashSpace(line: string): string {
+  let start = 0;
+  let end = line.length;
+
+  while (true) {
+    // Remove starting '\ '. These have no effect.
+    while (startsWith(line, '\\ ', start, end)) {
+      start += 2;
+    }
+
+    // If the line now starts with regular whitespace, trim it.
+    if (startsWith(line, ' ', start, end)) {
+      start += 1;
+    } else {
+      // If there is none, we're done.
+      break;
+    }
+
+    // Remove more starting whitespace, and then check again for leading '\ ' etc.
+    while (startsWith(line, ' ', start, end)) {
+      start += 1;
+    }
+  }
+
+  while (true) {
+    /*
+    Remove trailing '\ ' resp. '\' (after line.trim()). These actually have an effect,
+    since they remove the linebreak. *But* if our markup generator emits '\ ' followed
+    by a line break, we still want the line break to count, so this is actually fixing
+    a bug.
+    */
+    if (endsWith(line, '\\', start, end)) {
+      end -= 1;
+    }
+    while (endsWith(line, '\\ ', start, end)) {
+      end -= 2;
+    }
+
+    // If the line now ends with regular whitespace, trim it.
+    if (endsWith(line, ' ', start, end)) {
+      end -= 1;
+    } else {
+      // If there is none, we're done.
+      break;
+    }
+
+    // Remove more ending whitespace, and then check again for trailing '\' etc.
+    while (endsWith(line, ' ', start, end)) {
+      end -= 1;
+    }
+  }
+
+  // Return subset of the line
+  line = line.substring(start, end);
+  line = line.replace(/\\ (?:\\ )+/g, '\\ ');
+  line = line.replace(/(?<![\\])([ ])\\ (?![`])/g, '$1');
+  line = line.replace(/(?<!:`)\\ ([ .])/g, '$1');
+  return line;
+}
+
+function checkLine(index: number, lines: string[], line: string): boolean {
+  if (index < 0 || index >= lines.length) {
+    return false;
+  }
+  return lines[index] === line;
+}
+
+function modifyLine(index: number, line: string, lines: string[]): boolean {
+  const raw_html = '.. raw:: html';
+  const dashes = '------------';
+  const hr = '  <hr>';
+  if (line !== '' && line !== raw_html && line !== dashes && line !== hr) {
+    return true;
+  }
+  if (line === raw_html || line === dashes) {
+    return false;
+  }
+  if (line === hr && checkLine(index - 2, lines, raw_html)) {
+    return false;
+  }
+  if (
+    line === '' &&
+    (checkLine(index + 1, lines, raw_html) ||
+      checkLine(index - 1, lines, raw_html) ||
+      checkLine(index - 3, lines, raw_html))
+  ) {
+    return false;
+  }
+  if (line === '' && (checkLine(index + 1, lines, dashes) || checkLine(index - 1, lines, dashes))) {
+    return false;
+  }
+  return true;
+}
+
+export function postprocessRSTParagraph(par: string): string {
+  let lines = splitLines(par.trim());
+  lines = lines.map((line, index) =>
+    modifyLine(index, line, lines) ? removeBackslashSpace(line.trim().replace('\t', ' ')) : line,
+  );
+  return lines.filter((line, index) => (modifyLine(index, line, lines) ? !!line : true)).join('\n');
 }
 
 function formatAntsibullOptionLike(part: OptionNamePart | ReturnValuePart, role: string): string {
@@ -133,10 +236,8 @@ export function toRST(paragraphs: Paragraph[], opts?: RSTOptions): string {
   for (const paragraph of paragraphs) {
     const line: string[] = [];
     addToDestination(line, paragraph, mergedOpts);
-    if (!line.length) {
-      line.push('\\ ');
-    }
-    result.push(line.join(''));
+    const lineStr = postprocessRSTParagraph(line.join(''));
+    result.push(lineStr || '\\');
   }
   return result.join('\n\n');
 }

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -1,0 +1,56 @@
+/*
+  Simplified BSD License (see LICENSES/BSD-2-Clause.txt or https://opensource.org/licenses/BSD-2-Clause)
+  SPDX-FileCopyrightText: Ansible Project
+  SPDX-License-Identifier: BSD-2-Clause
+*/
+
+import { splitLines, startsWith, endsWith } from './util';
+
+describe('splitLines tests', (): void => {
+  it('empty string', (): void => {
+    expect(splitLines('')).toStrictEqual([]);
+  });
+  it('single line-break', (): void => {
+    expect(splitLines('\n')).toStrictEqual(['']);
+  });
+  it('two lines', (): void => {
+    expect(splitLines('a\nb')).toStrictEqual(['a', 'b']);
+  });
+  it('two lines ending with newline', (): void => {
+    expect(splitLines('a\nb\n')).toStrictEqual(['a', 'b']);
+  });
+});
+
+describe('startsWith tests', (): void => {
+  it('empty string', (): void => {
+    expect(startsWith('', ' ')).toBe(false);
+  });
+  it('middle match', (): void => {
+    expect(startsWith(' a ', ' ', 1, 2)).toBe(false);
+    expect(startsWith(' a ', 'a', 1, 2)).toBe(true);
+  });
+  it('no end', (): void => {
+    expect(startsWith(' a ', ' ', 1)).toBe(false);
+    expect(startsWith(' a ', 'a', 1)).toBe(true);
+  });
+  it('middle match too long', (): void => {
+    expect(startsWith(' a ', 'a ', 1, 2)).toBe(false);
+  });
+});
+
+describe('endsWith tests', (): void => {
+  it('empty string', (): void => {
+    expect(endsWith('', ' ')).toBe(false);
+  });
+  it('middle match', (): void => {
+    expect(endsWith(' a ', ' ', 1, 2)).toBe(false);
+    expect(endsWith(' a ', 'a', 1, 2)).toBe(true);
+  });
+  it('no end', (): void => {
+    expect(endsWith(' a', ' ', 1)).toBe(false);
+    expect(endsWith(' a', 'a', 1)).toBe(true);
+  });
+  it('middle match too long', (): void => {
+    expect(endsWith(' a ', 'a ', 1, 2)).toBe(false);
+  });
+});

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,42 @@
+/*
+  Simplified BSD License (see LICENSES/BSD-2-Clause.txt or https://opensource.org/licenses/BSD-2-Clause)
+  SPDX-FileCopyrightText: Ansible Project
+  SPDX-License-Identifier: BSD-2-Clause
+*/
+
+export function splitLines(line: string): string[] {
+  // The regex uses the line separators listed in https://docs.python.org/3/library/stdtypes.html#str.splitlines
+
+  /* eslint-disable-next-line no-control-regex */
+  const lines = line.split(/(?:\r\n|\n|\r|\v|\f|\x1c|\x1d|\x1e|\x85|\u2028|\u2029)/);
+  if (lines.length && lines[lines.length - 1] === '') {
+    lines.splice(lines.length - 1, 1);
+  }
+  return lines;
+}
+
+export function startsWith(text: string, prefix: string, start: number = 0, end?: number): boolean {
+  const prefixLen = prefix.length;
+  const textLen = text.length;
+  if (start < 0 || start + prefixLen > textLen) {
+    return false;
+  }
+  end = end ?? textLen;
+  if (start + prefixLen > end) {
+    return false;
+  }
+  return text.startsWith(prefix, start);
+}
+
+export function endsWith(text: string, prefix: string, start: number = 0, end?: number): boolean {
+  const prefixLen = prefix.length;
+  const textLen = text.length;
+  if (start < 0 || start + prefixLen > textLen) {
+    return false;
+  }
+  end = end ?? textLen;
+  if (start + prefixLen > end) {
+    return false;
+  }
+  return text.endsWith(prefix, end);
+}

--- a/test-vectors.yaml
+++ b/test-vectors.yaml
@@ -20,9 +20,11 @@ test_vectors:
     html_plain: |-
       <p></p>
     md: ' '
-    rst: '\ '
+    rst: |-
+      \
     ansible_doc_text: ''
-    rst_plain: '\ '
+    rst_plain: |-
+      \
   simple:
     source: This is a C(test) I(module) B(markup).
     html: |-
@@ -32,11 +34,11 @@ test_vectors:
     md: |-
       This is a <code>test</code> <em>module</em> <b>markup</b>\.
     rst: |-
-      This is a \ :literal:`test`\  \ :emphasis:`module`\  \ :strong:`markup`\ .
+      This is a :literal:`test` :emphasis:`module` :strong:`markup`.
     ansible_doc_text: |-
       This is a `test' `module' *markup*.
     rst_plain: |-
-      This is a \ :literal:`test`\  \ :emphasis:`module`\  \ :strong:`markup`\ .
+      This is a :literal:`test` :emphasis:`module` :strong:`markup`.
   empty_tags:
     source: C() I() B() C() U() L(,) L(foo,) L(,bar) R(,) V() O() RV() E()
     html: |-
@@ -45,12 +47,10 @@ test_vectors:
       <p><code></code> <em></em> <b></b> <code></code> <a href=''></a> <a href=''></a> <a href=''>foo</a> <a href='bar'></a> <span></span> <code></code> <code><strong></strong></code> <code></code> <code></code></p>
     md: |-
       <code></code> <em></em> <b></b> <code></code> []() []() [foo]() [](bar)  <code></code> <code><strong></strong></code> <code></code> <code></code>
-    rst: '\ :literal:`\ `\  \ :emphasis:`\ `\  \ :strong:`\ `\  \ :literal:`\ `\    foo  \
-      :ref:`\  <>`\  \ :ansval:`\ `\  \ :ansopt:`\ `\  \ :ansretval:`\ `\  \ :envvar:`\
-      `\ '
-    rst_plain: '\ :literal:`\ `\  \ :emphasis:`\ `\  \ :strong:`\ `\  \ :literal:`\
-      `\    foo  \ :ref:`\  <>`\  \ :literal:`\ `\  \ :literal:`\ `\  \ :literal:`\
-      `\  \ :envvar:`\ `\ '
+    rst: |-
+      :literal:`\ ` :emphasis:`\ ` :strong:`\ ` :literal:`\ `   foo  :ref:`\  <>` :ansval:`\ ` :ansopt:`\ ` :ansretval:`\ ` :envvar:`\ `
+    rst_plain: |-
+      :literal:`\ ` :emphasis:`\ ` :strong:`\ ` :literal:`\ `   foo  :ref:`\  <>` :literal:`\ ` :literal:`\ ` :literal:`\ ` :envvar:`\ `
     ansible_doc_text: |-
       `' `' ** `'   <> foo <>  <bar>  `' `' `' `'
   module:
@@ -66,11 +66,11 @@ test_vectors:
     md_opts:
       pluginLinkTemplate: https://docs.ansible.com/ansible/devel/collections/{plugin_fqcn_slashes}_{plugin_type}.html
     rst: |-
-      The \ :ref:`a.b.c <ansible_collections.a.b.c_module>`\  module.
+      The :ref:`a.b.c <ansible_collections.a.b.c_module>` module.
     ansible_doc_text: |-
       The [a.b.c] module.
     rst_plain: |-
-      The \ :ref:`a.b.c <ansible_collections.a.b.c_module>`\  module.
+      The :ref:`a.b.c <ansible_collections.a.b.c_module>` module.
   module_no_link:
     source: The M(a.b.c) module.
     html: |-
@@ -80,11 +80,11 @@ test_vectors:
     md: |-
       The a\.b\.c module\.
     rst: |-
-      The \ :ref:`a.b.c <ansible_collections.a.b.c_module>`\  module.
+      The :ref:`a.b.c <ansible_collections.a.b.c_module>` module.
     ansible_doc_text: |-
       The [a.b.c] module.
     rst_plain: |-
-      The \ :ref:`a.b.c <ansible_collections.a.b.c_module>`\  module.
+      The :ref:`a.b.c <ansible_collections.a.b.c_module>` module.
   plugin:
     source: The P(a.b.c#lookup) lookup plugin.
     html: |-
@@ -98,11 +98,11 @@ test_vectors:
     md_opts:
       pluginLinkTemplate: https://docs.ansible.com/ansible/devel/collections/{plugin_fqcn_slashes}_{plugin_type}.html
     rst: |-
-      The \ :ref:`a.b.c <ansible_collections.a.b.c_lookup>`\  lookup plugin.
+      The :ref:`a.b.c <ansible_collections.a.b.c_lookup>` lookup plugin.
     ansible_doc_text: |-
       The [a.b.c] lookup plugin.
     rst_plain: |-
-      The \ :ref:`a.b.c <ansible_collections.a.b.c_lookup>`\  lookup plugin.
+      The :ref:`a.b.c <ansible_collections.a.b.c_lookup>` lookup plugin.
   plugin_no_link:
     source: The P(a.b.c#lookup) lookup plugin.
     html: |-
@@ -112,11 +112,11 @@ test_vectors:
     md: |-
       The a\.b\.c lookup plugin\.
     rst: |-
-      The \ :ref:`a.b.c <ansible_collections.a.b.c_lookup>`\  lookup plugin.
+      The :ref:`a.b.c <ansible_collections.a.b.c_lookup>` lookup plugin.
     ansible_doc_text: |-
       The [a.b.c] lookup plugin.
     rst_plain: |-
-      The \ :ref:`a.b.c <ansible_collections.a.b.c_lookup>`\  lookup plugin.
+      The :ref:`a.b.c <ansible_collections.a.b.c_lookup>` lookup plugin.
   link_and_url:
     source: 'An URL U(https://example.com) and L(a link, https://example.org).
 
@@ -135,20 +135,18 @@ test_vectors:
       An URL [https\://example\.com](https\://example\.com) and [a link](https\://example\.org)\.
       With special characters\: [https\://example\.com/test\.html\?foo\=b\<a\>r\&find\=\\\*\#baz\.bam\%3D\(boo](https\://example\.com/test\.html\?foo\=b\%3Ca\%3Er\&find\=\%5C\*\#baz\.bam\%253D\(boo)
       and [mee\.boo](https\://example\.org/test\.html\?foo\=b\%3Ca\%3Er\&find\=\%5C\*\#baz\.bam\%253D\(boo)
-    rst: "An URL \\ `https://example.com <https://example.com>`__\\  and \\ `a link\
-      \ <https://example.org>`__\\ .\nWith special characters: \\ `https://example.com/test.html?foo=b\\\
-      <a\\>r&find=\\\\\\*#baz.bam%3D(boo <https://example.com/test.html?foo=b%3Ca%3Er&find=%5C*#baz.bam%253D(boo>`__\\\
-      \ \nand \\ `mee.boo <https://example.org/test.html?foo=b%3Ca%3Er&find=%5C*#baz.bam%253D(boo>`__\\\
-      \ "
+    rst: |-
+      An URL \ `https://example.com <https://example.com>`__ and \ `a link <https://example.org>`__.
+      With special characters: \ `https://example.com/test.html?foo=b\<a\>r&find=\\\*#baz.bam%3D(boo <https://example.com/test.html?foo=b%3Ca%3Er&find=%5C*#baz.bam%253D(boo>`__
+      and \ `mee.boo <https://example.org/test.html?foo=b%3Ca%3Er&find=%5C*#baz.bam%253D(boo>`__
     ansible_doc_text: |-
       An URL https://example.com and a link <https://example.org>.
       With special characters: https://example.com/test.html?foo=b<a>r&find=\*#baz.bam%3D(boo
       and mee.boo <https://example.org/test.html?foo=b<a>r&find=\*#baz.bam%3D(boo>
-    rst_plain: "An URL \\ `https://example.com <https://example.com>`__\\  and \\\
-      \ `a link <https://example.org>`__\\ .\nWith special characters: \\ `https://example.com/test.html?foo=b\\\
-      <a\\>r&find=\\\\\\*#baz.bam%3D(boo <https://example.com/test.html?foo=b%3Ca%3Er&find=%5C*#baz.bam%253D(boo>`__\\\
-      \ \nand \\ `mee.boo <https://example.org/test.html?foo=b%3Ca%3Er&find=%5C*#baz.bam%253D(boo>`__\\\
-      \ "
+    rst_plain: |-
+      An URL \ `https://example.com <https://example.com>`__ and \ `a link <https://example.org>`__.
+      With special characters: \ `https://example.com/test.html?foo=b\<a\>r&find=\\\*#baz.bam%3D(boo <https://example.com/test.html?foo=b%3Ca%3Er&find=%5C*#baz.bam%253D(boo>`__
+      and \ `mee.boo <https://example.org/test.html?foo=b%3Ca%3Er&find=%5C*#baz.bam%253D(boo>`__
   rst_ref:
     source: A R(RST reference, ansible_collections.community.general.ufw_module).
     html: |-
@@ -158,11 +156,11 @@ test_vectors:
     md: |-
       A RST reference\.
     rst: |-
-      A \ :ref:`RST reference <ansible_collections.community.general.ufw_module>`\ .
+      A :ref:`RST reference <ansible_collections.community.general.ufw_module>`.
     ansible_doc_text: |-
       A RST reference.
     rst_plain: |-
-      A \ :ref:`RST reference <ansible_collections.community.general.ufw_module>`\ .
+      A :ref:`RST reference <ansible_collections.community.general.ufw_module>`.
   horizontal_line:
     source: foo HORIZONTALLINE bar
     html: |-
@@ -198,11 +196,11 @@ test_vectors:
     md: |-
       foo <code>FOOBAR</code> bar foo\.bar\.baz has value <code> foo\)\,bar\\bam </code>\.
     rst: |-
-      foo \ :envvar:`FOOBAR`\  bar \ :ref:`foo.bar.baz <ansible_collections.foo.bar.baz_bam>`\  has value \ :ansval:`\  foo),bar\\bam \ `\ .
+      foo :envvar:`FOOBAR` bar :ref:`foo.bar.baz <ansible_collections.foo.bar.baz_bam>` has value :ansval:`\  foo),bar\\bam \ `.
     ansible_doc_text: |-
       foo `FOOBAR' bar [foo.bar.baz] has value ` foo),bar\bam '.
     rst_plain: |-
-      foo \ :envvar:`FOOBAR`\  bar \ :ref:`foo.bar.baz <ansible_collections.foo.bar.baz_bam>`\  has value \ :literal:`\  foo),bar\\bam \ `\ .
+      foo :envvar:`FOOBAR` bar :ref:`foo.bar.baz <ansible_collections.foo.bar.baz_bam>` has value :literal:`\  foo),bar\\bam \ `.
   option_name_no_current_plugin:
     source:
       - O(foo) O(bar.baz[123].bam[len(x\) - 1])
@@ -251,19 +249,30 @@ test_vectors:
       <code>foo\=</code> <code>bar\.baz\[123\]\.bam\[len\(x\) \- 1\]\=</code>
 
       <code>foo\=bar</code> <code>bar\.baz\[123\]\.bam\[len\(x\) \- 1\]\=bar</code>
-    rst: "\\ :ansopt:`foo`\\  \\ :ansopt:`bar.baz[123].bam[len(x) - 1]`\\ \n\n\\ :ansopt:`foo=`\\\
-      \  \\ :ansopt:`bar.baz[123].bam[len(x) - 1]=`\\ \n\n\\ :ansopt:`foo=bar`\\ \
-      \ \\ :ansopt:`bar.baz[123].bam[len(x) - 1]=bar`\\ \n\n\\ :ansopt:`bam.baz.foo#lookup:foo`\\\
-      \  \\ :ansopt:`bam.baz.foo#lookup:bar.baz[123].bam[len(x) - 1]`\\ \n\n\\ :ansopt:`bam.baz.foo#lookup:foo=`\\\
-      \  \\ :ansopt:`bam.baz.foo#lookup:bar.baz[123].bam[len(x) - 1]=`\\ \n\n\\ :ansopt:`bam.baz.foo#lookup:foo=bar`\\\
-      \  \\ :ansopt:`bam.baz.foo#lookup:bar.baz[123].bam[len(x) - 1]=bar`\\ \n\n\\\
-      \ :ansopt:`bam.baz.foo#role:main:foo`\\  \\ :ansopt:`bam.baz.foo#role:main:bar.baz[123].bam[len(x)\
-      \ - 1]`\\ \n\n\\ :ansopt:`bam.baz.foo#role:main:foo=`\\  \\ :ansopt:`bam.baz.foo#role:main:bar.baz[123].bam[len(x)\
-      \ - 1]=`\\ \n\n\\ :ansopt:`bam.baz.foo#role:main:foo=bar`\\  \\ :ansopt:`bam.baz.foo#role:main:bar.baz[123].bam[len(x)\
-      \ - 1]=bar`\\ \n\n\\ :ansopt:`foo`\\  \\ :ansopt:`bar.baz[123].bam[len(x) -\
-      \ 1]`\\ \n\n\\ :ansopt:`foo=`\\  \\ :ansopt:`bar.baz[123].bam[len(x) - 1]=`\\\
-      \ \n\n\\ :ansopt:`foo=bar`\\  \\ :ansopt:`bar.baz[123].bam[len(x) - 1]=bar`\\\
-      \ "
+    rst: |-
+      :ansopt:`foo` :ansopt:`bar.baz[123].bam[len(x) - 1]`
+
+      :ansopt:`foo=` :ansopt:`bar.baz[123].bam[len(x) - 1]=`
+
+      :ansopt:`foo=bar` :ansopt:`bar.baz[123].bam[len(x) - 1]=bar`
+
+      :ansopt:`bam.baz.foo#lookup:foo` :ansopt:`bam.baz.foo#lookup:bar.baz[123].bam[len(x) - 1]`
+
+      :ansopt:`bam.baz.foo#lookup:foo=` :ansopt:`bam.baz.foo#lookup:bar.baz[123].bam[len(x) - 1]=`
+
+      :ansopt:`bam.baz.foo#lookup:foo=bar` :ansopt:`bam.baz.foo#lookup:bar.baz[123].bam[len(x) - 1]=bar`
+
+      :ansopt:`bam.baz.foo#role:main:foo` :ansopt:`bam.baz.foo#role:main:bar.baz[123].bam[len(x) - 1]`
+
+      :ansopt:`bam.baz.foo#role:main:foo=` :ansopt:`bam.baz.foo#role:main:bar.baz[123].bam[len(x) - 1]=`
+
+      :ansopt:`bam.baz.foo#role:main:foo=bar` :ansopt:`bam.baz.foo#role:main:bar.baz[123].bam[len(x) - 1]=bar`
+
+      :ansopt:`foo` :ansopt:`bar.baz[123].bam[len(x) - 1]`
+
+      :ansopt:`foo=` :ansopt:`bar.baz[123].bam[len(x) - 1]=`
+
+      :ansopt:`foo=bar` :ansopt:`bar.baz[123].bam[len(x) - 1]=bar`
     ansible_doc_text: |-
       `foo' `bar.baz[123].bam[len(x) - 1]'
 
@@ -288,29 +297,30 @@ test_vectors:
       `foo=' `bar.baz[123].bam[len(x) - 1]='
 
       `foo=bar' `bar.baz[123].bam[len(x) - 1]=bar'
-    rst_plain: "\\ :literal:`foo`\\  \\ :literal:`bar.baz[123].bam[len(x) - 1]`\\\
-      \ \n\n\\ :literal:`foo=`\\  \\ :literal:`bar.baz[123].bam[len(x) - 1]=`\\ \n\
-      \n\\ :literal:`foo=bar`\\  \\ :literal:`bar.baz[123].bam[len(x) - 1]=bar`\\\
-      \ \n\n\\ :literal:`foo` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)\\\
-      \  \\ :literal:`bar.baz[123].bam[len(x) - 1]` (of lookup plugin :ref:`bam.baz.foo\
-      \ <ansible_collections.bam.baz.foo_lookup>`)\\ \n\n\\ :literal:`foo=` (of lookup\
-      \ plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)\\  \\\
-      \ :literal:`bar.baz[123].bam[len(x) - 1]=` (of lookup plugin :ref:`bam.baz.foo\
-      \ <ansible_collections.bam.baz.foo_lookup>`)\\ \n\n\\ :literal:`foo=bar` (of\
-      \ lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)\\\
-      \  \\ :literal:`bar.baz[123].bam[len(x) - 1]=bar` (of lookup plugin :ref:`bam.baz.foo\
-      \ <ansible_collections.bam.baz.foo_lookup>`)\\ \n\n\\ :literal:`foo` (of role\
-      \ :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`, entrypoint main)\\\
-      \  \\ :literal:`bar.baz[123].bam[len(x) - 1]` (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`,\
-      \ entrypoint main)\\ \n\n\\ :literal:`foo=` (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`,\
-      \ entrypoint main)\\  \\ :literal:`bar.baz[123].bam[len(x) - 1]=` (of role :ref:`bam.baz.foo\
-      \ <ansible_collections.bam.baz.foo_role>`, entrypoint main)\\ \n\n\\ :literal:`foo=bar`\
-      \ (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`, entrypoint\
-      \ main)\\  \\ :literal:`bar.baz[123].bam[len(x) - 1]=bar` (of role :ref:`bam.baz.foo\
-      \ <ansible_collections.bam.baz.foo_role>`, entrypoint main)\\ \n\n\\ :literal:`foo`\\\
-      \  \\ :literal:`bar.baz[123].bam[len(x) - 1]`\\ \n\n\\ :literal:`foo=`\\  \\\
-      \ :literal:`bar.baz[123].bam[len(x) - 1]=`\\ \n\n\\ :literal:`foo=bar`\\  \\\
-      \ :literal:`bar.baz[123].bam[len(x) - 1]=bar`\\ "
+    rst_plain: |-
+      :literal:`foo` :literal:`bar.baz[123].bam[len(x) - 1]`
+
+      :literal:`foo=` :literal:`bar.baz[123].bam[len(x) - 1]=`
+
+      :literal:`foo=bar` :literal:`bar.baz[123].bam[len(x) - 1]=bar`
+
+      :literal:`foo` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`) :literal:`bar.baz[123].bam[len(x) - 1]` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)
+
+      :literal:`foo=` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`) :literal:`bar.baz[123].bam[len(x) - 1]=` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)
+
+      :literal:`foo=bar` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`) :literal:`bar.baz[123].bam[len(x) - 1]=bar` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)
+
+      :literal:`foo` (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`, entrypoint main) :literal:`bar.baz[123].bam[len(x) - 1]` (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`, entrypoint main)
+
+      :literal:`foo=` (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`, entrypoint main) :literal:`bar.baz[123].bam[len(x) - 1]=` (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`, entrypoint main)
+
+      :literal:`foo=bar` (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`, entrypoint main) :literal:`bar.baz[123].bam[len(x) - 1]=bar` (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`, entrypoint main)
+
+      :literal:`foo` :literal:`bar.baz[123].bam[len(x) - 1]`
+
+      :literal:`foo=` :literal:`bar.baz[123].bam[len(x) - 1]=`
+
+      :literal:`foo=bar` :literal:`bar.baz[123].bam[len(x) - 1]=bar`
   option_name_current_plugin:
     source:
       - O(foo) O(bar.baz[123].bam[len(x\) - 1])
@@ -359,19 +369,30 @@ test_vectors:
       <code>foo\=</code> <code>bar\.baz\[123\]\.bam\[len\(x\) \- 1\]\=</code>
 
       <code>foo\=bar</code> <code>bar\.baz\[123\]\.bam\[len\(x\) \- 1\]\=bar</code>
-    rst: "\\ :ansopt:`foo.bar.baz.bam#boo:foo`\\  \\ :ansopt:`foo.bar.baz.bam#boo:bar.baz[123].bam[len(x)\
-      \ - 1]`\\ \n\n\\ :ansopt:`foo.bar.baz.bam#boo:foo=`\\  \\ :ansopt:`foo.bar.baz.bam#boo:bar.baz[123].bam[len(x)\
-      \ - 1]=`\\ \n\n\\ :ansopt:`foo.bar.baz.bam#boo:foo=bar`\\  \\ :ansopt:`foo.bar.baz.bam#boo:bar.baz[123].bam[len(x)\
-      \ - 1]=bar`\\ \n\n\\ :ansopt:`bam.baz.foo#lookup:foo`\\  \\ :ansopt:`bam.baz.foo#lookup:bar.baz[123].bam[len(x)\
-      \ - 1]`\\ \n\n\\ :ansopt:`bam.baz.foo#lookup:foo=`\\  \\ :ansopt:`bam.baz.foo#lookup:bar.baz[123].bam[len(x)\
-      \ - 1]=`\\ \n\n\\ :ansopt:`bam.baz.foo#lookup:foo=bar`\\  \\ :ansopt:`bam.baz.foo#lookup:bar.baz[123].bam[len(x)\
-      \ - 1]=bar`\\ \n\n\\ :ansopt:`bam.baz.foo#role:main:foo`\\  \\ :ansopt:`bam.baz.foo#role:main:bar.baz[123].bam[len(x)\
-      \ - 1]`\\ \n\n\\ :ansopt:`bam.baz.foo#role:main:foo=`\\  \\ :ansopt:`bam.baz.foo#role:main:bar.baz[123].bam[len(x)\
-      \ - 1]=`\\ \n\n\\ :ansopt:`bam.baz.foo#role:main:foo=bar`\\  \\ :ansopt:`bam.baz.foo#role:main:bar.baz[123].bam[len(x)\
-      \ - 1]=bar`\\ \n\n\\ :ansopt:`foo`\\  \\ :ansopt:`bar.baz[123].bam[len(x) -\
-      \ 1]`\\ \n\n\\ :ansopt:`foo=`\\  \\ :ansopt:`bar.baz[123].bam[len(x) - 1]=`\\\
-      \ \n\n\\ :ansopt:`foo=bar`\\  \\ :ansopt:`bar.baz[123].bam[len(x) - 1]=bar`\\\
-      \ "
+    rst: |-
+      :ansopt:`foo.bar.baz.bam#boo:foo` :ansopt:`foo.bar.baz.bam#boo:bar.baz[123].bam[len(x) - 1]`
+
+      :ansopt:`foo.bar.baz.bam#boo:foo=` :ansopt:`foo.bar.baz.bam#boo:bar.baz[123].bam[len(x) - 1]=`
+
+      :ansopt:`foo.bar.baz.bam#boo:foo=bar` :ansopt:`foo.bar.baz.bam#boo:bar.baz[123].bam[len(x) - 1]=bar`
+
+      :ansopt:`bam.baz.foo#lookup:foo` :ansopt:`bam.baz.foo#lookup:bar.baz[123].bam[len(x) - 1]`
+
+      :ansopt:`bam.baz.foo#lookup:foo=` :ansopt:`bam.baz.foo#lookup:bar.baz[123].bam[len(x) - 1]=`
+
+      :ansopt:`bam.baz.foo#lookup:foo=bar` :ansopt:`bam.baz.foo#lookup:bar.baz[123].bam[len(x) - 1]=bar`
+
+      :ansopt:`bam.baz.foo#role:main:foo` :ansopt:`bam.baz.foo#role:main:bar.baz[123].bam[len(x) - 1]`
+
+      :ansopt:`bam.baz.foo#role:main:foo=` :ansopt:`bam.baz.foo#role:main:bar.baz[123].bam[len(x) - 1]=`
+
+      :ansopt:`bam.baz.foo#role:main:foo=bar` :ansopt:`bam.baz.foo#role:main:bar.baz[123].bam[len(x) - 1]=bar`
+
+      :ansopt:`foo` :ansopt:`bar.baz[123].bam[len(x) - 1]`
+
+      :ansopt:`foo=` :ansopt:`bar.baz[123].bam[len(x) - 1]=`
+
+      :ansopt:`foo=bar` :ansopt:`bar.baz[123].bam[len(x) - 1]=bar`
     parse_opts:
       currentPlugin:
         fqcn: foo.bar.baz.bam
@@ -400,35 +421,30 @@ test_vectors:
       `foo=' `bar.baz[123].bam[len(x) - 1]='
 
       `foo=bar' `bar.baz[123].bam[len(x) - 1]=bar'
-    rst_plain: "\\ :literal:`foo` (of boo plugin :ref:`foo.bar.baz.bam <ansible_collections.foo.bar.baz.bam_boo>`)\\\
-      \  \\ :literal:`bar.baz[123].bam[len(x) - 1]` (of boo plugin :ref:`foo.bar.baz.bam\
-      \ <ansible_collections.foo.bar.baz.bam_boo>`)\\ \n\n\\ :literal:`foo=` (of boo\
-      \ plugin :ref:`foo.bar.baz.bam <ansible_collections.foo.bar.baz.bam_boo>`)\\\
-      \  \\ :literal:`bar.baz[123].bam[len(x) - 1]=` (of boo plugin :ref:`foo.bar.baz.bam\
-      \ <ansible_collections.foo.bar.baz.bam_boo>`)\\ \n\n\\ :literal:`foo=bar` (of\
-      \ boo plugin :ref:`foo.bar.baz.bam <ansible_collections.foo.bar.baz.bam_boo>`)\\\
-      \  \\ :literal:`bar.baz[123].bam[len(x) - 1]=bar` (of boo plugin :ref:`foo.bar.baz.bam\
-      \ <ansible_collections.foo.bar.baz.bam_boo>`)\\ \n\n\\ :literal:`foo` (of lookup\
-      \ plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)\\  \\\
-      \ :literal:`bar.baz[123].bam[len(x) - 1]` (of lookup plugin :ref:`bam.baz.foo\
-      \ <ansible_collections.bam.baz.foo_lookup>`)\\ \n\n\\ :literal:`foo=` (of lookup\
-      \ plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)\\  \\\
-      \ :literal:`bar.baz[123].bam[len(x) - 1]=` (of lookup plugin :ref:`bam.baz.foo\
-      \ <ansible_collections.bam.baz.foo_lookup>`)\\ \n\n\\ :literal:`foo=bar` (of\
-      \ lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)\\\
-      \  \\ :literal:`bar.baz[123].bam[len(x) - 1]=bar` (of lookup plugin :ref:`bam.baz.foo\
-      \ <ansible_collections.bam.baz.foo_lookup>`)\\ \n\n\\ :literal:`foo` (of role\
-      \ :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`, entrypoint main)\\\
-      \  \\ :literal:`bar.baz[123].bam[len(x) - 1]` (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`,\
-      \ entrypoint main)\\ \n\n\\ :literal:`foo=` (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`,\
-      \ entrypoint main)\\  \\ :literal:`bar.baz[123].bam[len(x) - 1]=` (of role :ref:`bam.baz.foo\
-      \ <ansible_collections.bam.baz.foo_role>`, entrypoint main)\\ \n\n\\ :literal:`foo=bar`\
-      \ (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`, entrypoint\
-      \ main)\\  \\ :literal:`bar.baz[123].bam[len(x) - 1]=bar` (of role :ref:`bam.baz.foo\
-      \ <ansible_collections.bam.baz.foo_role>`, entrypoint main)\\ \n\n\\ :literal:`foo`\\\
-      \  \\ :literal:`bar.baz[123].bam[len(x) - 1]`\\ \n\n\\ :literal:`foo=`\\  \\\
-      \ :literal:`bar.baz[123].bam[len(x) - 1]=`\\ \n\n\\ :literal:`foo=bar`\\  \\\
-      \ :literal:`bar.baz[123].bam[len(x) - 1]=bar`\\ "
+    rst_plain: |-
+      :literal:`foo` (of boo plugin :ref:`foo.bar.baz.bam <ansible_collections.foo.bar.baz.bam_boo>`) :literal:`bar.baz[123].bam[len(x) - 1]` (of boo plugin :ref:`foo.bar.baz.bam <ansible_collections.foo.bar.baz.bam_boo>`)
+
+      :literal:`foo=` (of boo plugin :ref:`foo.bar.baz.bam <ansible_collections.foo.bar.baz.bam_boo>`) :literal:`bar.baz[123].bam[len(x) - 1]=` (of boo plugin :ref:`foo.bar.baz.bam <ansible_collections.foo.bar.baz.bam_boo>`)
+
+      :literal:`foo=bar` (of boo plugin :ref:`foo.bar.baz.bam <ansible_collections.foo.bar.baz.bam_boo>`) :literal:`bar.baz[123].bam[len(x) - 1]=bar` (of boo plugin :ref:`foo.bar.baz.bam <ansible_collections.foo.bar.baz.bam_boo>`)
+
+      :literal:`foo` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`) :literal:`bar.baz[123].bam[len(x) - 1]` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)
+
+      :literal:`foo=` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`) :literal:`bar.baz[123].bam[len(x) - 1]=` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)
+
+      :literal:`foo=bar` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`) :literal:`bar.baz[123].bam[len(x) - 1]=bar` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)
+
+      :literal:`foo` (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`, entrypoint main) :literal:`bar.baz[123].bam[len(x) - 1]` (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`, entrypoint main)
+
+      :literal:`foo=` (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`, entrypoint main) :literal:`bar.baz[123].bam[len(x) - 1]=` (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`, entrypoint main)
+
+      :literal:`foo=bar` (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`, entrypoint main) :literal:`bar.baz[123].bam[len(x) - 1]=bar` (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`, entrypoint main)
+
+      :literal:`foo` :literal:`bar.baz[123].bam[len(x) - 1]`
+
+      :literal:`foo=` :literal:`bar.baz[123].bam[len(x) - 1]=`
+
+      :literal:`foo=bar` :literal:`bar.baz[123].bam[len(x) - 1]=bar`
   option_name_current_role:
     source:
       - O(foo) O(bar.baz[123].bam[len(x\) - 1])
@@ -487,24 +503,36 @@ test_vectors:
       <code>foo\=</code> <code>bar\.baz\[123\]\.bam\[len\(x\) \- 1\]\=</code>
 
       <code>foo\=bar</code> <code>bar\.baz\[123\]\.bam\[len\(x\) \- 1\]\=bar</code>
-    rst: "\\ :ansopt:`foo.bar.baz#role:main:foo`\\  \\ :ansopt:`foo.bar.baz#role:main:bar.baz[123].bam[len(x)\
-      \ - 1]`\\ \n\n\\ :ansopt:`foo.bar.baz#role:main:foo=`\\  \\ :ansopt:`foo.bar.baz#role:main:bar.baz[123].bam[len(x)\
-      \ - 1]=`\\ \n\n\\ :ansopt:`foo.bar.baz#role:main:foo=bar`\\  \\ :ansopt:`foo.bar.baz#role:main:bar.baz[123].bam[len(x)\
-      \ - 1]=bar`\\ \n\n\\ :ansopt:`foo.bar.baz#role:other\\_entrypoint:foo`\\  \\\
-      \ :ansopt:`foo.bar.baz#role:other\\_entrypoint:bar.baz[123].bam[len(x) - 1]`\\\
-      \ \n\n\\ :ansopt:`foo.bar.baz#role:other\\_entrypoint:foo=`\\  \\ :ansopt:`foo.bar.baz#role:other\\\
-      _entrypoint:bar.baz[123].bam[len(x) - 1]=`\\ \n\n\\ :ansopt:`foo.bar.baz#role:other\\\
-      _entrypoint:foo=bar`\\  \\ :ansopt:`foo.bar.baz#role:other\\_entrypoint:bar.baz[123].bam[len(x)\
-      \ - 1]=bar`\\ \n\n\\ :ansopt:`bam.baz.foo#lookup:foo`\\  \\ :ansopt:`bam.baz.foo#lookup:bar.baz[123].bam[len(x)\
-      \ - 1]`\\ \n\n\\ :ansopt:`bam.baz.foo#lookup:foo=`\\  \\ :ansopt:`bam.baz.foo#lookup:bar.baz[123].bam[len(x)\
-      \ - 1]=`\\ \n\n\\ :ansopt:`bam.baz.foo#lookup:foo=bar`\\  \\ :ansopt:`bam.baz.foo#lookup:bar.baz[123].bam[len(x)\
-      \ - 1]=bar`\\ \n\n\\ :ansopt:`bam.baz.foo#role:main:foo`\\  \\ :ansopt:`bam.baz.foo#role:main:bar.baz[123].bam[len(x)\
-      \ - 1]`\\ \n\n\\ :ansopt:`bam.baz.foo#role:main:foo=`\\  \\ :ansopt:`bam.baz.foo#role:main:bar.baz[123].bam[len(x)\
-      \ - 1]=`\\ \n\n\\ :ansopt:`bam.baz.foo#role:main:foo=bar`\\  \\ :ansopt:`bam.baz.foo#role:main:bar.baz[123].bam[len(x)\
-      \ - 1]=bar`\\ \n\n\\ :ansopt:`foo`\\  \\ :ansopt:`bar.baz[123].bam[len(x) -\
-      \ 1]`\\ \n\n\\ :ansopt:`foo=`\\  \\ :ansopt:`bar.baz[123].bam[len(x) - 1]=`\\\
-      \ \n\n\\ :ansopt:`foo=bar`\\  \\ :ansopt:`bar.baz[123].bam[len(x) - 1]=bar`\\\
-      \ "
+    rst: |-
+      :ansopt:`foo.bar.baz#role:main:foo` :ansopt:`foo.bar.baz#role:main:bar.baz[123].bam[len(x) - 1]`
+
+      :ansopt:`foo.bar.baz#role:main:foo=` :ansopt:`foo.bar.baz#role:main:bar.baz[123].bam[len(x) - 1]=`
+
+      :ansopt:`foo.bar.baz#role:main:foo=bar` :ansopt:`foo.bar.baz#role:main:bar.baz[123].bam[len(x) - 1]=bar`
+
+      :ansopt:`foo.bar.baz#role:other\_entrypoint:foo` :ansopt:`foo.bar.baz#role:other\_entrypoint:bar.baz[123].bam[len(x) - 1]`
+
+      :ansopt:`foo.bar.baz#role:other\_entrypoint:foo=` :ansopt:`foo.bar.baz#role:other\_entrypoint:bar.baz[123].bam[len(x) - 1]=`
+
+      :ansopt:`foo.bar.baz#role:other\_entrypoint:foo=bar` :ansopt:`foo.bar.baz#role:other\_entrypoint:bar.baz[123].bam[len(x) - 1]=bar`
+
+      :ansopt:`bam.baz.foo#lookup:foo` :ansopt:`bam.baz.foo#lookup:bar.baz[123].bam[len(x) - 1]`
+
+      :ansopt:`bam.baz.foo#lookup:foo=` :ansopt:`bam.baz.foo#lookup:bar.baz[123].bam[len(x) - 1]=`
+
+      :ansopt:`bam.baz.foo#lookup:foo=bar` :ansopt:`bam.baz.foo#lookup:bar.baz[123].bam[len(x) - 1]=bar`
+
+      :ansopt:`bam.baz.foo#role:main:foo` :ansopt:`bam.baz.foo#role:main:bar.baz[123].bam[len(x) - 1]`
+
+      :ansopt:`bam.baz.foo#role:main:foo=` :ansopt:`bam.baz.foo#role:main:bar.baz[123].bam[len(x) - 1]=`
+
+      :ansopt:`bam.baz.foo#role:main:foo=bar` :ansopt:`bam.baz.foo#role:main:bar.baz[123].bam[len(x) - 1]=bar`
+
+      :ansopt:`foo` :ansopt:`bar.baz[123].bam[len(x) - 1]`
+
+      :ansopt:`foo=` :ansopt:`bar.baz[123].bam[len(x) - 1]=`
+
+      :ansopt:`foo=bar` :ansopt:`bar.baz[123].bam[len(x) - 1]=bar`
     parse_opts:
       currentPlugin:
         fqcn: foo.bar.baz
@@ -540,45 +568,36 @@ test_vectors:
       `foo=' `bar.baz[123].bam[len(x) - 1]='
 
       `foo=bar' `bar.baz[123].bam[len(x) - 1]=bar'
-    rst_plain: "\\ :literal:`foo` (of role :ref:`foo.bar.baz <ansible_collections.foo.bar.baz_role>`,\
-      \ entrypoint main)\\  \\ :literal:`bar.baz[123].bam[len(x) - 1]` (of role :ref:`foo.bar.baz\
-      \ <ansible_collections.foo.bar.baz_role>`, entrypoint main)\\ \n\n\\ :literal:`foo=`\
-      \ (of role :ref:`foo.bar.baz <ansible_collections.foo.bar.baz_role>`, entrypoint\
-      \ main)\\  \\ :literal:`bar.baz[123].bam[len(x) - 1]=` (of role :ref:`foo.bar.baz\
-      \ <ansible_collections.foo.bar.baz_role>`, entrypoint main)\\ \n\n\\ :literal:`foo=bar`\
-      \ (of role :ref:`foo.bar.baz <ansible_collections.foo.bar.baz_role>`, entrypoint\
-      \ main)\\  \\ :literal:`bar.baz[123].bam[len(x) - 1]=bar` (of role :ref:`foo.bar.baz\
-      \ <ansible_collections.foo.bar.baz_role>`, entrypoint main)\\ \n\n\\ :literal:`foo`\
-      \ (of role :ref:`foo.bar.baz <ansible_collections.foo.bar.baz_role>`, entrypoint\
-      \ other\\_entrypoint)\\  \\ :literal:`bar.baz[123].bam[len(x) - 1]` (of role\
-      \ :ref:`foo.bar.baz <ansible_collections.foo.bar.baz_role>`, entrypoint other\\\
-      _entrypoint)\\ \n\n\\ :literal:`foo=` (of role :ref:`foo.bar.baz <ansible_collections.foo.bar.baz_role>`,\
-      \ entrypoint other\\_entrypoint)\\  \\ :literal:`bar.baz[123].bam[len(x) - 1]=`\
-      \ (of role :ref:`foo.bar.baz <ansible_collections.foo.bar.baz_role>`, entrypoint\
-      \ other\\_entrypoint)\\ \n\n\\ :literal:`foo=bar` (of role :ref:`foo.bar.baz\
-      \ <ansible_collections.foo.bar.baz_role>`, entrypoint other\\_entrypoint)\\\
-      \  \\ :literal:`bar.baz[123].bam[len(x) - 1]=bar` (of role :ref:`foo.bar.baz\
-      \ <ansible_collections.foo.bar.baz_role>`, entrypoint other\\_entrypoint)\\\
-      \ \n\n\\ :literal:`foo` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)\\\
-      \  \\ :literal:`bar.baz[123].bam[len(x) - 1]` (of lookup plugin :ref:`bam.baz.foo\
-      \ <ansible_collections.bam.baz.foo_lookup>`)\\ \n\n\\ :literal:`foo=` (of lookup\
-      \ plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)\\  \\\
-      \ :literal:`bar.baz[123].bam[len(x) - 1]=` (of lookup plugin :ref:`bam.baz.foo\
-      \ <ansible_collections.bam.baz.foo_lookup>`)\\ \n\n\\ :literal:`foo=bar` (of\
-      \ lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)\\\
-      \  \\ :literal:`bar.baz[123].bam[len(x) - 1]=bar` (of lookup plugin :ref:`bam.baz.foo\
-      \ <ansible_collections.bam.baz.foo_lookup>`)\\ \n\n\\ :literal:`foo` (of role\
-      \ :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`, entrypoint main)\\\
-      \  \\ :literal:`bar.baz[123].bam[len(x) - 1]` (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`,\
-      \ entrypoint main)\\ \n\n\\ :literal:`foo=` (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`,\
-      \ entrypoint main)\\  \\ :literal:`bar.baz[123].bam[len(x) - 1]=` (of role :ref:`bam.baz.foo\
-      \ <ansible_collections.bam.baz.foo_role>`, entrypoint main)\\ \n\n\\ :literal:`foo=bar`\
-      \ (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`, entrypoint\
-      \ main)\\  \\ :literal:`bar.baz[123].bam[len(x) - 1]=bar` (of role :ref:`bam.baz.foo\
-      \ <ansible_collections.bam.baz.foo_role>`, entrypoint main)\\ \n\n\\ :literal:`foo`\\\
-      \  \\ :literal:`bar.baz[123].bam[len(x) - 1]`\\ \n\n\\ :literal:`foo=`\\  \\\
-      \ :literal:`bar.baz[123].bam[len(x) - 1]=`\\ \n\n\\ :literal:`foo=bar`\\  \\\
-      \ :literal:`bar.baz[123].bam[len(x) - 1]=bar`\\ "
+    rst_plain: |-
+      :literal:`foo` (of role :ref:`foo.bar.baz <ansible_collections.foo.bar.baz_role>`, entrypoint main) :literal:`bar.baz[123].bam[len(x) - 1]` (of role :ref:`foo.bar.baz <ansible_collections.foo.bar.baz_role>`, entrypoint main)
+
+      :literal:`foo=` (of role :ref:`foo.bar.baz <ansible_collections.foo.bar.baz_role>`, entrypoint main) :literal:`bar.baz[123].bam[len(x) - 1]=` (of role :ref:`foo.bar.baz <ansible_collections.foo.bar.baz_role>`, entrypoint main)
+
+      :literal:`foo=bar` (of role :ref:`foo.bar.baz <ansible_collections.foo.bar.baz_role>`, entrypoint main) :literal:`bar.baz[123].bam[len(x) - 1]=bar` (of role :ref:`foo.bar.baz <ansible_collections.foo.bar.baz_role>`, entrypoint main)
+
+      :literal:`foo` (of role :ref:`foo.bar.baz <ansible_collections.foo.bar.baz_role>`, entrypoint other\_entrypoint) :literal:`bar.baz[123].bam[len(x) - 1]` (of role :ref:`foo.bar.baz <ansible_collections.foo.bar.baz_role>`, entrypoint other\_entrypoint)
+
+      :literal:`foo=` (of role :ref:`foo.bar.baz <ansible_collections.foo.bar.baz_role>`, entrypoint other\_entrypoint) :literal:`bar.baz[123].bam[len(x) - 1]=` (of role :ref:`foo.bar.baz <ansible_collections.foo.bar.baz_role>`, entrypoint other\_entrypoint)
+
+      :literal:`foo=bar` (of role :ref:`foo.bar.baz <ansible_collections.foo.bar.baz_role>`, entrypoint other\_entrypoint) :literal:`bar.baz[123].bam[len(x) - 1]=bar` (of role :ref:`foo.bar.baz <ansible_collections.foo.bar.baz_role>`, entrypoint other\_entrypoint)
+
+      :literal:`foo` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`) :literal:`bar.baz[123].bam[len(x) - 1]` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)
+
+      :literal:`foo=` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`) :literal:`bar.baz[123].bam[len(x) - 1]=` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)
+
+      :literal:`foo=bar` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`) :literal:`bar.baz[123].bam[len(x) - 1]=bar` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)
+
+      :literal:`foo` (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`, entrypoint main) :literal:`bar.baz[123].bam[len(x) - 1]` (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`, entrypoint main)
+
+      :literal:`foo=` (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`, entrypoint main) :literal:`bar.baz[123].bam[len(x) - 1]=` (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`, entrypoint main)
+
+      :literal:`foo=bar` (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`, entrypoint main) :literal:`bar.baz[123].bam[len(x) - 1]=bar` (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`, entrypoint main)
+
+      :literal:`foo` :literal:`bar.baz[123].bam[len(x) - 1]`
+
+      :literal:`foo=` :literal:`bar.baz[123].bam[len(x) - 1]=`
+
+      :literal:`foo=bar` :literal:`bar.baz[123].bam[len(x) - 1]=bar`
   option_name_no_current_plugin_w_links:
     source:
       - O(foo) O(bar.baz[123].bam[len(x\) - 1])
@@ -631,19 +650,30 @@ test_vectors:
       <code>foo\=bar</code> <code>bar\.baz\[123\]\.bam\[len\(x\) \- 1\]\=bar</code>
     md_opts:
       pluginOptionLikeLinkTemplate: https://docs.ansible.com/ansible/devel/collections/{plugin_fqcn_slashes}_{plugin_type}.html#{what}{entrypoint_with_leading_dash}-{name_slashes}
-    rst: "\\ :ansopt:`foo`\\  \\ :ansopt:`bar.baz[123].bam[len(x) - 1]`\\ \n\n\\ :ansopt:`foo=`\\\
-      \  \\ :ansopt:`bar.baz[123].bam[len(x) - 1]=`\\ \n\n\\ :ansopt:`foo=bar`\\ \
-      \ \\ :ansopt:`bar.baz[123].bam[len(x) - 1]=bar`\\ \n\n\\ :ansopt:`bam.baz.foo#lookup:foo`\\\
-      \  \\ :ansopt:`bam.baz.foo#lookup:bar.baz[123].bam[len(x) - 1]`\\ \n\n\\ :ansopt:`bam.baz.foo#lookup:foo=`\\\
-      \  \\ :ansopt:`bam.baz.foo#lookup:bar.baz[123].bam[len(x) - 1]=`\\ \n\n\\ :ansopt:`bam.baz.foo#lookup:foo=bar`\\\
-      \  \\ :ansopt:`bam.baz.foo#lookup:bar.baz[123].bam[len(x) - 1]=bar`\\ \n\n\\\
-      \ :ansopt:`bam.baz.foo#role:main:foo`\\  \\ :ansopt:`bam.baz.foo#role:main:bar.baz[123].bam[len(x)\
-      \ - 1]`\\ \n\n\\ :ansopt:`bam.baz.foo#role:main:foo=`\\  \\ :ansopt:`bam.baz.foo#role:main:bar.baz[123].bam[len(x)\
-      \ - 1]=`\\ \n\n\\ :ansopt:`bam.baz.foo#role:main:foo=bar`\\  \\ :ansopt:`bam.baz.foo#role:main:bar.baz[123].bam[len(x)\
-      \ - 1]=bar`\\ \n\n\\ :ansopt:`foo`\\  \\ :ansopt:`bar.baz[123].bam[len(x) -\
-      \ 1]`\\ \n\n\\ :ansopt:`foo=`\\  \\ :ansopt:`bar.baz[123].bam[len(x) - 1]=`\\\
-      \ \n\n\\ :ansopt:`foo=bar`\\  \\ :ansopt:`bar.baz[123].bam[len(x) - 1]=bar`\\\
-      \ "
+    rst: |-
+      :ansopt:`foo` :ansopt:`bar.baz[123].bam[len(x) - 1]`
+
+      :ansopt:`foo=` :ansopt:`bar.baz[123].bam[len(x) - 1]=`
+
+      :ansopt:`foo=bar` :ansopt:`bar.baz[123].bam[len(x) - 1]=bar`
+
+      :ansopt:`bam.baz.foo#lookup:foo` :ansopt:`bam.baz.foo#lookup:bar.baz[123].bam[len(x) - 1]`
+
+      :ansopt:`bam.baz.foo#lookup:foo=` :ansopt:`bam.baz.foo#lookup:bar.baz[123].bam[len(x) - 1]=`
+
+      :ansopt:`bam.baz.foo#lookup:foo=bar` :ansopt:`bam.baz.foo#lookup:bar.baz[123].bam[len(x) - 1]=bar`
+
+      :ansopt:`bam.baz.foo#role:main:foo` :ansopt:`bam.baz.foo#role:main:bar.baz[123].bam[len(x) - 1]`
+
+      :ansopt:`bam.baz.foo#role:main:foo=` :ansopt:`bam.baz.foo#role:main:bar.baz[123].bam[len(x) - 1]=`
+
+      :ansopt:`bam.baz.foo#role:main:foo=bar` :ansopt:`bam.baz.foo#role:main:bar.baz[123].bam[len(x) - 1]=bar`
+
+      :ansopt:`foo` :ansopt:`bar.baz[123].bam[len(x) - 1]`
+
+      :ansopt:`foo=` :ansopt:`bar.baz[123].bam[len(x) - 1]=`
+
+      :ansopt:`foo=bar` :ansopt:`bar.baz[123].bam[len(x) - 1]=bar`
     ansible_doc_text: |-
       `foo' `bar.baz[123].bam[len(x) - 1]'
 
@@ -668,29 +698,30 @@ test_vectors:
       `foo=' `bar.baz[123].bam[len(x) - 1]='
 
       `foo=bar' `bar.baz[123].bam[len(x) - 1]=bar'
-    rst_plain: "\\ :literal:`foo`\\  \\ :literal:`bar.baz[123].bam[len(x) - 1]`\\\
-      \ \n\n\\ :literal:`foo=`\\  \\ :literal:`bar.baz[123].bam[len(x) - 1]=`\\ \n\
-      \n\\ :literal:`foo=bar`\\  \\ :literal:`bar.baz[123].bam[len(x) - 1]=bar`\\\
-      \ \n\n\\ :literal:`foo` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)\\\
-      \  \\ :literal:`bar.baz[123].bam[len(x) - 1]` (of lookup plugin :ref:`bam.baz.foo\
-      \ <ansible_collections.bam.baz.foo_lookup>`)\\ \n\n\\ :literal:`foo=` (of lookup\
-      \ plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)\\  \\\
-      \ :literal:`bar.baz[123].bam[len(x) - 1]=` (of lookup plugin :ref:`bam.baz.foo\
-      \ <ansible_collections.bam.baz.foo_lookup>`)\\ \n\n\\ :literal:`foo=bar` (of\
-      \ lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)\\\
-      \  \\ :literal:`bar.baz[123].bam[len(x) - 1]=bar` (of lookup plugin :ref:`bam.baz.foo\
-      \ <ansible_collections.bam.baz.foo_lookup>`)\\ \n\n\\ :literal:`foo` (of role\
-      \ :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`, entrypoint main)\\\
-      \  \\ :literal:`bar.baz[123].bam[len(x) - 1]` (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`,\
-      \ entrypoint main)\\ \n\n\\ :literal:`foo=` (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`,\
-      \ entrypoint main)\\  \\ :literal:`bar.baz[123].bam[len(x) - 1]=` (of role :ref:`bam.baz.foo\
-      \ <ansible_collections.bam.baz.foo_role>`, entrypoint main)\\ \n\n\\ :literal:`foo=bar`\
-      \ (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`, entrypoint\
-      \ main)\\  \\ :literal:`bar.baz[123].bam[len(x) - 1]=bar` (of role :ref:`bam.baz.foo\
-      \ <ansible_collections.bam.baz.foo_role>`, entrypoint main)\\ \n\n\\ :literal:`foo`\\\
-      \  \\ :literal:`bar.baz[123].bam[len(x) - 1]`\\ \n\n\\ :literal:`foo=`\\  \\\
-      \ :literal:`bar.baz[123].bam[len(x) - 1]=`\\ \n\n\\ :literal:`foo=bar`\\  \\\
-      \ :literal:`bar.baz[123].bam[len(x) - 1]=bar`\\ "
+    rst_plain: |-
+      :literal:`foo` :literal:`bar.baz[123].bam[len(x) - 1]`
+
+      :literal:`foo=` :literal:`bar.baz[123].bam[len(x) - 1]=`
+
+      :literal:`foo=bar` :literal:`bar.baz[123].bam[len(x) - 1]=bar`
+
+      :literal:`foo` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`) :literal:`bar.baz[123].bam[len(x) - 1]` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)
+
+      :literal:`foo=` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`) :literal:`bar.baz[123].bam[len(x) - 1]=` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)
+
+      :literal:`foo=bar` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`) :literal:`bar.baz[123].bam[len(x) - 1]=bar` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)
+
+      :literal:`foo` (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`, entrypoint main) :literal:`bar.baz[123].bam[len(x) - 1]` (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`, entrypoint main)
+
+      :literal:`foo=` (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`, entrypoint main) :literal:`bar.baz[123].bam[len(x) - 1]=` (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`, entrypoint main)
+
+      :literal:`foo=bar` (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`, entrypoint main) :literal:`bar.baz[123].bam[len(x) - 1]=bar` (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`, entrypoint main)
+
+      :literal:`foo` :literal:`bar.baz[123].bam[len(x) - 1]`
+
+      :literal:`foo=` :literal:`bar.baz[123].bam[len(x) - 1]=`
+
+      :literal:`foo=bar` :literal:`bar.baz[123].bam[len(x) - 1]=bar`
   option_name_current_plugin_w_links:
     source:
       - O(foo) O(bar.baz[123].bam[len(x\) - 1])
@@ -743,19 +774,30 @@ test_vectors:
       <code>foo\=bar</code> <code>bar\.baz\[123\]\.bam\[len\(x\) \- 1\]\=bar</code>
     md_opts:
       pluginOptionLikeLinkTemplate: https://docs.ansible.com/ansible/devel/collections/{plugin_fqcn_slashes}_{plugin_type}.html#{what}{entrypoint_with_leading_dash}-{name_slashes}
-    rst: "\\ :ansopt:`foo.bar.baz.bam#boo:foo`\\  \\ :ansopt:`foo.bar.baz.bam#boo:bar.baz[123].bam[len(x)\
-      \ - 1]`\\ \n\n\\ :ansopt:`foo.bar.baz.bam#boo:foo=`\\  \\ :ansopt:`foo.bar.baz.bam#boo:bar.baz[123].bam[len(x)\
-      \ - 1]=`\\ \n\n\\ :ansopt:`foo.bar.baz.bam#boo:foo=bar`\\  \\ :ansopt:`foo.bar.baz.bam#boo:bar.baz[123].bam[len(x)\
-      \ - 1]=bar`\\ \n\n\\ :ansopt:`bam.baz.foo#lookup:foo`\\  \\ :ansopt:`bam.baz.foo#lookup:bar.baz[123].bam[len(x)\
-      \ - 1]`\\ \n\n\\ :ansopt:`bam.baz.foo#lookup:foo=`\\  \\ :ansopt:`bam.baz.foo#lookup:bar.baz[123].bam[len(x)\
-      \ - 1]=`\\ \n\n\\ :ansopt:`bam.baz.foo#lookup:foo=bar`\\  \\ :ansopt:`bam.baz.foo#lookup:bar.baz[123].bam[len(x)\
-      \ - 1]=bar`\\ \n\n\\ :ansopt:`bam.baz.foo#role:main:foo`\\  \\ :ansopt:`bam.baz.foo#role:main:bar.baz[123].bam[len(x)\
-      \ - 1]`\\ \n\n\\ :ansopt:`bam.baz.foo#role:main:foo=`\\  \\ :ansopt:`bam.baz.foo#role:main:bar.baz[123].bam[len(x)\
-      \ - 1]=`\\ \n\n\\ :ansopt:`bam.baz.foo#role:main:foo=bar`\\  \\ :ansopt:`bam.baz.foo#role:main:bar.baz[123].bam[len(x)\
-      \ - 1]=bar`\\ \n\n\\ :ansopt:`foo`\\  \\ :ansopt:`bar.baz[123].bam[len(x) -\
-      \ 1]`\\ \n\n\\ :ansopt:`foo=`\\  \\ :ansopt:`bar.baz[123].bam[len(x) - 1]=`\\\
-      \ \n\n\\ :ansopt:`foo=bar`\\  \\ :ansopt:`bar.baz[123].bam[len(x) - 1]=bar`\\\
-      \ "
+    rst: |-
+      :ansopt:`foo.bar.baz.bam#boo:foo` :ansopt:`foo.bar.baz.bam#boo:bar.baz[123].bam[len(x) - 1]`
+
+      :ansopt:`foo.bar.baz.bam#boo:foo=` :ansopt:`foo.bar.baz.bam#boo:bar.baz[123].bam[len(x) - 1]=`
+
+      :ansopt:`foo.bar.baz.bam#boo:foo=bar` :ansopt:`foo.bar.baz.bam#boo:bar.baz[123].bam[len(x) - 1]=bar`
+
+      :ansopt:`bam.baz.foo#lookup:foo` :ansopt:`bam.baz.foo#lookup:bar.baz[123].bam[len(x) - 1]`
+
+      :ansopt:`bam.baz.foo#lookup:foo=` :ansopt:`bam.baz.foo#lookup:bar.baz[123].bam[len(x) - 1]=`
+
+      :ansopt:`bam.baz.foo#lookup:foo=bar` :ansopt:`bam.baz.foo#lookup:bar.baz[123].bam[len(x) - 1]=bar`
+
+      :ansopt:`bam.baz.foo#role:main:foo` :ansopt:`bam.baz.foo#role:main:bar.baz[123].bam[len(x) - 1]`
+
+      :ansopt:`bam.baz.foo#role:main:foo=` :ansopt:`bam.baz.foo#role:main:bar.baz[123].bam[len(x) - 1]=`
+
+      :ansopt:`bam.baz.foo#role:main:foo=bar` :ansopt:`bam.baz.foo#role:main:bar.baz[123].bam[len(x) - 1]=bar`
+
+      :ansopt:`foo` :ansopt:`bar.baz[123].bam[len(x) - 1]`
+
+      :ansopt:`foo=` :ansopt:`bar.baz[123].bam[len(x) - 1]=`
+
+      :ansopt:`foo=bar` :ansopt:`bar.baz[123].bam[len(x) - 1]=bar`
     parse_opts:
       currentPlugin:
         fqcn: foo.bar.baz.bam
@@ -784,35 +826,30 @@ test_vectors:
       `foo=' `bar.baz[123].bam[len(x) - 1]='
 
       `foo=bar' `bar.baz[123].bam[len(x) - 1]=bar'
-    rst_plain: "\\ :literal:`foo` (of boo plugin :ref:`foo.bar.baz.bam <ansible_collections.foo.bar.baz.bam_boo>`)\\\
-      \  \\ :literal:`bar.baz[123].bam[len(x) - 1]` (of boo plugin :ref:`foo.bar.baz.bam\
-      \ <ansible_collections.foo.bar.baz.bam_boo>`)\\ \n\n\\ :literal:`foo=` (of boo\
-      \ plugin :ref:`foo.bar.baz.bam <ansible_collections.foo.bar.baz.bam_boo>`)\\\
-      \  \\ :literal:`bar.baz[123].bam[len(x) - 1]=` (of boo plugin :ref:`foo.bar.baz.bam\
-      \ <ansible_collections.foo.bar.baz.bam_boo>`)\\ \n\n\\ :literal:`foo=bar` (of\
-      \ boo plugin :ref:`foo.bar.baz.bam <ansible_collections.foo.bar.baz.bam_boo>`)\\\
-      \  \\ :literal:`bar.baz[123].bam[len(x) - 1]=bar` (of boo plugin :ref:`foo.bar.baz.bam\
-      \ <ansible_collections.foo.bar.baz.bam_boo>`)\\ \n\n\\ :literal:`foo` (of lookup\
-      \ plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)\\  \\\
-      \ :literal:`bar.baz[123].bam[len(x) - 1]` (of lookup plugin :ref:`bam.baz.foo\
-      \ <ansible_collections.bam.baz.foo_lookup>`)\\ \n\n\\ :literal:`foo=` (of lookup\
-      \ plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)\\  \\\
-      \ :literal:`bar.baz[123].bam[len(x) - 1]=` (of lookup plugin :ref:`bam.baz.foo\
-      \ <ansible_collections.bam.baz.foo_lookup>`)\\ \n\n\\ :literal:`foo=bar` (of\
-      \ lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)\\\
-      \  \\ :literal:`bar.baz[123].bam[len(x) - 1]=bar` (of lookup plugin :ref:`bam.baz.foo\
-      \ <ansible_collections.bam.baz.foo_lookup>`)\\ \n\n\\ :literal:`foo` (of role\
-      \ :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`, entrypoint main)\\\
-      \  \\ :literal:`bar.baz[123].bam[len(x) - 1]` (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`,\
-      \ entrypoint main)\\ \n\n\\ :literal:`foo=` (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`,\
-      \ entrypoint main)\\  \\ :literal:`bar.baz[123].bam[len(x) - 1]=` (of role :ref:`bam.baz.foo\
-      \ <ansible_collections.bam.baz.foo_role>`, entrypoint main)\\ \n\n\\ :literal:`foo=bar`\
-      \ (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`, entrypoint\
-      \ main)\\  \\ :literal:`bar.baz[123].bam[len(x) - 1]=bar` (of role :ref:`bam.baz.foo\
-      \ <ansible_collections.bam.baz.foo_role>`, entrypoint main)\\ \n\n\\ :literal:`foo`\\\
-      \  \\ :literal:`bar.baz[123].bam[len(x) - 1]`\\ \n\n\\ :literal:`foo=`\\  \\\
-      \ :literal:`bar.baz[123].bam[len(x) - 1]=`\\ \n\n\\ :literal:`foo=bar`\\  \\\
-      \ :literal:`bar.baz[123].bam[len(x) - 1]=bar`\\ "
+    rst_plain: |-
+      :literal:`foo` (of boo plugin :ref:`foo.bar.baz.bam <ansible_collections.foo.bar.baz.bam_boo>`) :literal:`bar.baz[123].bam[len(x) - 1]` (of boo plugin :ref:`foo.bar.baz.bam <ansible_collections.foo.bar.baz.bam_boo>`)
+
+      :literal:`foo=` (of boo plugin :ref:`foo.bar.baz.bam <ansible_collections.foo.bar.baz.bam_boo>`) :literal:`bar.baz[123].bam[len(x) - 1]=` (of boo plugin :ref:`foo.bar.baz.bam <ansible_collections.foo.bar.baz.bam_boo>`)
+
+      :literal:`foo=bar` (of boo plugin :ref:`foo.bar.baz.bam <ansible_collections.foo.bar.baz.bam_boo>`) :literal:`bar.baz[123].bam[len(x) - 1]=bar` (of boo plugin :ref:`foo.bar.baz.bam <ansible_collections.foo.bar.baz.bam_boo>`)
+
+      :literal:`foo` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`) :literal:`bar.baz[123].bam[len(x) - 1]` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)
+
+      :literal:`foo=` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`) :literal:`bar.baz[123].bam[len(x) - 1]=` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)
+
+      :literal:`foo=bar` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`) :literal:`bar.baz[123].bam[len(x) - 1]=bar` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)
+
+      :literal:`foo` (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`, entrypoint main) :literal:`bar.baz[123].bam[len(x) - 1]` (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`, entrypoint main)
+
+      :literal:`foo=` (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`, entrypoint main) :literal:`bar.baz[123].bam[len(x) - 1]=` (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`, entrypoint main)
+
+      :literal:`foo=bar` (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`, entrypoint main) :literal:`bar.baz[123].bam[len(x) - 1]=bar` (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`, entrypoint main)
+
+      :literal:`foo` :literal:`bar.baz[123].bam[len(x) - 1]`
+
+      :literal:`foo=` :literal:`bar.baz[123].bam[len(x) - 1]=`
+
+      :literal:`foo=bar` :literal:`bar.baz[123].bam[len(x) - 1]=bar`
   option_name_current_role_w_links:
     source:
       - O(foo) O(bar.baz[123].bam[len(x\) - 1])
@@ -875,24 +912,36 @@ test_vectors:
       <code>foo\=bar</code> <code>bar\.baz\[123\]\.bam\[len\(x\) \- 1\]\=bar</code>
     md_opts:
       pluginOptionLikeLinkTemplate: https://docs.ansible.com/ansible/devel/collections/{plugin_fqcn_slashes}_{plugin_type}.html#{what}{entrypoint_with_leading_dash}-{name_slashes}
-    rst: "\\ :ansopt:`foo.bar.baz#role:main:foo`\\  \\ :ansopt:`foo.bar.baz#role:main:bar.baz[123].bam[len(x)\
-      \ - 1]`\\ \n\n\\ :ansopt:`foo.bar.baz#role:main:foo=`\\  \\ :ansopt:`foo.bar.baz#role:main:bar.baz[123].bam[len(x)\
-      \ - 1]=`\\ \n\n\\ :ansopt:`foo.bar.baz#role:main:foo=bar`\\  \\ :ansopt:`foo.bar.baz#role:main:bar.baz[123].bam[len(x)\
-      \ - 1]=bar`\\ \n\n\\ :ansopt:`foo.bar.baz#role:other\\_entrypoint:foo`\\  \\\
-      \ :ansopt:`foo.bar.baz#role:other\\_entrypoint:bar.baz[123].bam[len(x) - 1]`\\\
-      \ \n\n\\ :ansopt:`foo.bar.baz#role:other\\_entrypoint:foo=`\\  \\ :ansopt:`foo.bar.baz#role:other\\\
-      _entrypoint:bar.baz[123].bam[len(x) - 1]=`\\ \n\n\\ :ansopt:`foo.bar.baz#role:other\\\
-      _entrypoint:foo=bar`\\  \\ :ansopt:`foo.bar.baz#role:other\\_entrypoint:bar.baz[123].bam[len(x)\
-      \ - 1]=bar`\\ \n\n\\ :ansopt:`bam.baz.foo#lookup:foo`\\  \\ :ansopt:`bam.baz.foo#lookup:bar.baz[123].bam[len(x)\
-      \ - 1]`\\ \n\n\\ :ansopt:`bam.baz.foo#lookup:foo=`\\  \\ :ansopt:`bam.baz.foo#lookup:bar.baz[123].bam[len(x)\
-      \ - 1]=`\\ \n\n\\ :ansopt:`bam.baz.foo#lookup:foo=bar`\\  \\ :ansopt:`bam.baz.foo#lookup:bar.baz[123].bam[len(x)\
-      \ - 1]=bar`\\ \n\n\\ :ansopt:`bam.baz.foo#role:main:foo`\\  \\ :ansopt:`bam.baz.foo#role:main:bar.baz[123].bam[len(x)\
-      \ - 1]`\\ \n\n\\ :ansopt:`bam.baz.foo#role:main:foo=`\\  \\ :ansopt:`bam.baz.foo#role:main:bar.baz[123].bam[len(x)\
-      \ - 1]=`\\ \n\n\\ :ansopt:`bam.baz.foo#role:main:foo=bar`\\  \\ :ansopt:`bam.baz.foo#role:main:bar.baz[123].bam[len(x)\
-      \ - 1]=bar`\\ \n\n\\ :ansopt:`foo`\\  \\ :ansopt:`bar.baz[123].bam[len(x) -\
-      \ 1]`\\ \n\n\\ :ansopt:`foo=`\\  \\ :ansopt:`bar.baz[123].bam[len(x) - 1]=`\\\
-      \ \n\n\\ :ansopt:`foo=bar`\\  \\ :ansopt:`bar.baz[123].bam[len(x) - 1]=bar`\\\
-      \ "
+    rst: |-
+      :ansopt:`foo.bar.baz#role:main:foo` :ansopt:`foo.bar.baz#role:main:bar.baz[123].bam[len(x) - 1]`
+
+      :ansopt:`foo.bar.baz#role:main:foo=` :ansopt:`foo.bar.baz#role:main:bar.baz[123].bam[len(x) - 1]=`
+
+      :ansopt:`foo.bar.baz#role:main:foo=bar` :ansopt:`foo.bar.baz#role:main:bar.baz[123].bam[len(x) - 1]=bar`
+
+      :ansopt:`foo.bar.baz#role:other\_entrypoint:foo` :ansopt:`foo.bar.baz#role:other\_entrypoint:bar.baz[123].bam[len(x) - 1]`
+
+      :ansopt:`foo.bar.baz#role:other\_entrypoint:foo=` :ansopt:`foo.bar.baz#role:other\_entrypoint:bar.baz[123].bam[len(x) - 1]=`
+
+      :ansopt:`foo.bar.baz#role:other\_entrypoint:foo=bar` :ansopt:`foo.bar.baz#role:other\_entrypoint:bar.baz[123].bam[len(x) - 1]=bar`
+
+      :ansopt:`bam.baz.foo#lookup:foo` :ansopt:`bam.baz.foo#lookup:bar.baz[123].bam[len(x) - 1]`
+
+      :ansopt:`bam.baz.foo#lookup:foo=` :ansopt:`bam.baz.foo#lookup:bar.baz[123].bam[len(x) - 1]=`
+
+      :ansopt:`bam.baz.foo#lookup:foo=bar` :ansopt:`bam.baz.foo#lookup:bar.baz[123].bam[len(x) - 1]=bar`
+
+      :ansopt:`bam.baz.foo#role:main:foo` :ansopt:`bam.baz.foo#role:main:bar.baz[123].bam[len(x) - 1]`
+
+      :ansopt:`bam.baz.foo#role:main:foo=` :ansopt:`bam.baz.foo#role:main:bar.baz[123].bam[len(x) - 1]=`
+
+      :ansopt:`bam.baz.foo#role:main:foo=bar` :ansopt:`bam.baz.foo#role:main:bar.baz[123].bam[len(x) - 1]=bar`
+
+      :ansopt:`foo` :ansopt:`bar.baz[123].bam[len(x) - 1]`
+
+      :ansopt:`foo=` :ansopt:`bar.baz[123].bam[len(x) - 1]=`
+
+      :ansopt:`foo=bar` :ansopt:`bar.baz[123].bam[len(x) - 1]=bar`
     parse_opts:
       currentPlugin:
         fqcn: foo.bar.baz
@@ -928,45 +977,36 @@ test_vectors:
       `foo=' `bar.baz[123].bam[len(x) - 1]='
 
       `foo=bar' `bar.baz[123].bam[len(x) - 1]=bar'
-    rst_plain: "\\ :literal:`foo` (of role :ref:`foo.bar.baz <ansible_collections.foo.bar.baz_role>`,\
-      \ entrypoint main)\\  \\ :literal:`bar.baz[123].bam[len(x) - 1]` (of role :ref:`foo.bar.baz\
-      \ <ansible_collections.foo.bar.baz_role>`, entrypoint main)\\ \n\n\\ :literal:`foo=`\
-      \ (of role :ref:`foo.bar.baz <ansible_collections.foo.bar.baz_role>`, entrypoint\
-      \ main)\\  \\ :literal:`bar.baz[123].bam[len(x) - 1]=` (of role :ref:`foo.bar.baz\
-      \ <ansible_collections.foo.bar.baz_role>`, entrypoint main)\\ \n\n\\ :literal:`foo=bar`\
-      \ (of role :ref:`foo.bar.baz <ansible_collections.foo.bar.baz_role>`, entrypoint\
-      \ main)\\  \\ :literal:`bar.baz[123].bam[len(x) - 1]=bar` (of role :ref:`foo.bar.baz\
-      \ <ansible_collections.foo.bar.baz_role>`, entrypoint main)\\ \n\n\\ :literal:`foo`\
-      \ (of role :ref:`foo.bar.baz <ansible_collections.foo.bar.baz_role>`, entrypoint\
-      \ other\\_entrypoint)\\  \\ :literal:`bar.baz[123].bam[len(x) - 1]` (of role\
-      \ :ref:`foo.bar.baz <ansible_collections.foo.bar.baz_role>`, entrypoint other\\\
-      _entrypoint)\\ \n\n\\ :literal:`foo=` (of role :ref:`foo.bar.baz <ansible_collections.foo.bar.baz_role>`,\
-      \ entrypoint other\\_entrypoint)\\  \\ :literal:`bar.baz[123].bam[len(x) - 1]=`\
-      \ (of role :ref:`foo.bar.baz <ansible_collections.foo.bar.baz_role>`, entrypoint\
-      \ other\\_entrypoint)\\ \n\n\\ :literal:`foo=bar` (of role :ref:`foo.bar.baz\
-      \ <ansible_collections.foo.bar.baz_role>`, entrypoint other\\_entrypoint)\\\
-      \  \\ :literal:`bar.baz[123].bam[len(x) - 1]=bar` (of role :ref:`foo.bar.baz\
-      \ <ansible_collections.foo.bar.baz_role>`, entrypoint other\\_entrypoint)\\\
-      \ \n\n\\ :literal:`foo` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)\\\
-      \  \\ :literal:`bar.baz[123].bam[len(x) - 1]` (of lookup plugin :ref:`bam.baz.foo\
-      \ <ansible_collections.bam.baz.foo_lookup>`)\\ \n\n\\ :literal:`foo=` (of lookup\
-      \ plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)\\  \\\
-      \ :literal:`bar.baz[123].bam[len(x) - 1]=` (of lookup plugin :ref:`bam.baz.foo\
-      \ <ansible_collections.bam.baz.foo_lookup>`)\\ \n\n\\ :literal:`foo=bar` (of\
-      \ lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)\\\
-      \  \\ :literal:`bar.baz[123].bam[len(x) - 1]=bar` (of lookup plugin :ref:`bam.baz.foo\
-      \ <ansible_collections.bam.baz.foo_lookup>`)\\ \n\n\\ :literal:`foo` (of role\
-      \ :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`, entrypoint main)\\\
-      \  \\ :literal:`bar.baz[123].bam[len(x) - 1]` (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`,\
-      \ entrypoint main)\\ \n\n\\ :literal:`foo=` (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`,\
-      \ entrypoint main)\\  \\ :literal:`bar.baz[123].bam[len(x) - 1]=` (of role :ref:`bam.baz.foo\
-      \ <ansible_collections.bam.baz.foo_role>`, entrypoint main)\\ \n\n\\ :literal:`foo=bar`\
-      \ (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`, entrypoint\
-      \ main)\\  \\ :literal:`bar.baz[123].bam[len(x) - 1]=bar` (of role :ref:`bam.baz.foo\
-      \ <ansible_collections.bam.baz.foo_role>`, entrypoint main)\\ \n\n\\ :literal:`foo`\\\
-      \  \\ :literal:`bar.baz[123].bam[len(x) - 1]`\\ \n\n\\ :literal:`foo=`\\  \\\
-      \ :literal:`bar.baz[123].bam[len(x) - 1]=`\\ \n\n\\ :literal:`foo=bar`\\  \\\
-      \ :literal:`bar.baz[123].bam[len(x) - 1]=bar`\\ "
+    rst_plain: |-
+      :literal:`foo` (of role :ref:`foo.bar.baz <ansible_collections.foo.bar.baz_role>`, entrypoint main) :literal:`bar.baz[123].bam[len(x) - 1]` (of role :ref:`foo.bar.baz <ansible_collections.foo.bar.baz_role>`, entrypoint main)
+
+      :literal:`foo=` (of role :ref:`foo.bar.baz <ansible_collections.foo.bar.baz_role>`, entrypoint main) :literal:`bar.baz[123].bam[len(x) - 1]=` (of role :ref:`foo.bar.baz <ansible_collections.foo.bar.baz_role>`, entrypoint main)
+
+      :literal:`foo=bar` (of role :ref:`foo.bar.baz <ansible_collections.foo.bar.baz_role>`, entrypoint main) :literal:`bar.baz[123].bam[len(x) - 1]=bar` (of role :ref:`foo.bar.baz <ansible_collections.foo.bar.baz_role>`, entrypoint main)
+
+      :literal:`foo` (of role :ref:`foo.bar.baz <ansible_collections.foo.bar.baz_role>`, entrypoint other\_entrypoint) :literal:`bar.baz[123].bam[len(x) - 1]` (of role :ref:`foo.bar.baz <ansible_collections.foo.bar.baz_role>`, entrypoint other\_entrypoint)
+
+      :literal:`foo=` (of role :ref:`foo.bar.baz <ansible_collections.foo.bar.baz_role>`, entrypoint other\_entrypoint) :literal:`bar.baz[123].bam[len(x) - 1]=` (of role :ref:`foo.bar.baz <ansible_collections.foo.bar.baz_role>`, entrypoint other\_entrypoint)
+
+      :literal:`foo=bar` (of role :ref:`foo.bar.baz <ansible_collections.foo.bar.baz_role>`, entrypoint other\_entrypoint) :literal:`bar.baz[123].bam[len(x) - 1]=bar` (of role :ref:`foo.bar.baz <ansible_collections.foo.bar.baz_role>`, entrypoint other\_entrypoint)
+
+      :literal:`foo` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`) :literal:`bar.baz[123].bam[len(x) - 1]` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)
+
+      :literal:`foo=` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`) :literal:`bar.baz[123].bam[len(x) - 1]=` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)
+
+      :literal:`foo=bar` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`) :literal:`bar.baz[123].bam[len(x) - 1]=bar` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)
+
+      :literal:`foo` (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`, entrypoint main) :literal:`bar.baz[123].bam[len(x) - 1]` (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`, entrypoint main)
+
+      :literal:`foo=` (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`, entrypoint main) :literal:`bar.baz[123].bam[len(x) - 1]=` (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`, entrypoint main)
+
+      :literal:`foo=bar` (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`, entrypoint main) :literal:`bar.baz[123].bam[len(x) - 1]=bar` (of role :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_role>`, entrypoint main)
+
+      :literal:`foo` :literal:`bar.baz[123].bam[len(x) - 1]`
+
+      :literal:`foo=` :literal:`bar.baz[123].bam[len(x) - 1]=`
+
+      :literal:`foo=bar` :literal:`bar.baz[123].bam[len(x) - 1]=bar`
   return_value_no_current_plugin:
     source:
       - RV(foo) RV(bar.baz[123].bam[len(x\) - 1])
@@ -1003,16 +1043,24 @@ test_vectors:
       <code>foo\=</code> <code>bar\.baz\[123\]\.bam\[len\(x\) \- 1\]\=</code>
 
       <code>foo\=bar</code> <code>bar\.baz\[123\]\.bam\[len\(x\) \- 1\]\=bar</code>
-    rst: "\\ :ansretval:`foo`\\  \\ :ansretval:`bar.baz[123].bam[len(x) - 1]`\\ \n\
-      \n\\ :ansretval:`foo=`\\  \\ :ansretval:`bar.baz[123].bam[len(x) - 1]=`\\ \n\
-      \n\\ :ansretval:`foo=bar`\\  \\ :ansretval:`bar.baz[123].bam[len(x) - 1]=bar`\\\
-      \ \n\n\\ :ansretval:`bam.baz.foo#lookup:foo`\\  \\ :ansretval:`bam.baz.foo#lookup:bar.baz[123].bam[len(x)\
-      \ - 1]`\\ \n\n\\ :ansretval:`bam.baz.foo#lookup:foo=`\\  \\ :ansretval:`bam.baz.foo#lookup:bar.baz[123].bam[len(x)\
-      \ - 1]=`\\ \n\n\\ :ansretval:`bam.baz.foo#lookup:foo=bar`\\  \\ :ansretval:`bam.baz.foo#lookup:bar.baz[123].bam[len(x)\
-      \ - 1]=bar`\\ \n\n\\ :ansretval:`foo`\\  \\ :ansretval:`bar.baz[123].bam[len(x)\
-      \ - 1]`\\ \n\n\\ :ansretval:`foo=`\\  \\ :ansretval:`bar.baz[123].bam[len(x)\
-      \ - 1]=`\\ \n\n\\ :ansretval:`foo=bar`\\  \\ :ansretval:`bar.baz[123].bam[len(x)\
-      \ - 1]=bar`\\ "
+    rst: |-
+      :ansretval:`foo` :ansretval:`bar.baz[123].bam[len(x) - 1]`
+
+      :ansretval:`foo=` :ansretval:`bar.baz[123].bam[len(x) - 1]=`
+
+      :ansretval:`foo=bar` :ansretval:`bar.baz[123].bam[len(x) - 1]=bar`
+
+      :ansretval:`bam.baz.foo#lookup:foo` :ansretval:`bam.baz.foo#lookup:bar.baz[123].bam[len(x) - 1]`
+
+      :ansretval:`bam.baz.foo#lookup:foo=` :ansretval:`bam.baz.foo#lookup:bar.baz[123].bam[len(x) - 1]=`
+
+      :ansretval:`bam.baz.foo#lookup:foo=bar` :ansretval:`bam.baz.foo#lookup:bar.baz[123].bam[len(x) - 1]=bar`
+
+      :ansretval:`foo` :ansretval:`bar.baz[123].bam[len(x) - 1]`
+
+      :ansretval:`foo=` :ansretval:`bar.baz[123].bam[len(x) - 1]=`
+
+      :ansretval:`foo=bar` :ansretval:`bar.baz[123].bam[len(x) - 1]=bar`
     ansible_doc_text: |-
       `foo' `bar.baz[123].bam[len(x) - 1]'
 
@@ -1031,21 +1079,24 @@ test_vectors:
       `foo=' `bar.baz[123].bam[len(x) - 1]='
 
       `foo=bar' `bar.baz[123].bam[len(x) - 1]=bar'
-    rst_plain: "\\ :literal:`foo`\\  \\ :literal:`bar.baz[123].bam[len(x) - 1]`\\\
-      \ \n\n\\ :literal:`foo=`\\  \\ :literal:`bar.baz[123].bam[len(x) - 1]=`\\ \n\
-      \n\\ :literal:`foo=bar`\\  \\ :literal:`bar.baz[123].bam[len(x) - 1]=bar`\\\
-      \ \n\n\\ :literal:`foo` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)\\\
-      \  \\ :literal:`bar.baz[123].bam[len(x) - 1]` (of lookup plugin :ref:`bam.baz.foo\
-      \ <ansible_collections.bam.baz.foo_lookup>`)\\ \n\n\\ :literal:`foo=` (of lookup\
-      \ plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)\\  \\\
-      \ :literal:`bar.baz[123].bam[len(x) - 1]=` (of lookup plugin :ref:`bam.baz.foo\
-      \ <ansible_collections.bam.baz.foo_lookup>`)\\ \n\n\\ :literal:`foo=bar` (of\
-      \ lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)\\\
-      \  \\ :literal:`bar.baz[123].bam[len(x) - 1]=bar` (of lookup plugin :ref:`bam.baz.foo\
-      \ <ansible_collections.bam.baz.foo_lookup>`)\\ \n\n\\ :literal:`foo`\\  \\ :literal:`bar.baz[123].bam[len(x)\
-      \ - 1]`\\ \n\n\\ :literal:`foo=`\\  \\ :literal:`bar.baz[123].bam[len(x) - 1]=`\\\
-      \ \n\n\\ :literal:`foo=bar`\\  \\ :literal:`bar.baz[123].bam[len(x) - 1]=bar`\\\
-      \ "
+    rst_plain: |-
+      :literal:`foo` :literal:`bar.baz[123].bam[len(x) - 1]`
+
+      :literal:`foo=` :literal:`bar.baz[123].bam[len(x) - 1]=`
+
+      :literal:`foo=bar` :literal:`bar.baz[123].bam[len(x) - 1]=bar`
+
+      :literal:`foo` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`) :literal:`bar.baz[123].bam[len(x) - 1]` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)
+
+      :literal:`foo=` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`) :literal:`bar.baz[123].bam[len(x) - 1]=` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)
+
+      :literal:`foo=bar` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`) :literal:`bar.baz[123].bam[len(x) - 1]=bar` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)
+
+      :literal:`foo` :literal:`bar.baz[123].bam[len(x) - 1]`
+
+      :literal:`foo=` :literal:`bar.baz[123].bam[len(x) - 1]=`
+
+      :literal:`foo=bar` :literal:`bar.baz[123].bam[len(x) - 1]=bar`
   return_value_current_plugin:
     source:
       - RV(foo) RV(bar.baz[123].bam[len(x\) - 1])
@@ -1082,16 +1133,24 @@ test_vectors:
       <code>foo\=</code> <code>bar\.baz\[123\]\.bam\[len\(x\) \- 1\]\=</code>
 
       <code>foo\=bar</code> <code>bar\.baz\[123\]\.bam\[len\(x\) \- 1\]\=bar</code>
-    rst: "\\ :ansretval:`foo.bar.baz.bam#boo:foo`\\  \\ :ansretval:`foo.bar.baz.bam#boo:bar.baz[123].bam[len(x)\
-      \ - 1]`\\ \n\n\\ :ansretval:`foo.bar.baz.bam#boo:foo=`\\  \\ :ansretval:`foo.bar.baz.bam#boo:bar.baz[123].bam[len(x)\
-      \ - 1]=`\\ \n\n\\ :ansretval:`foo.bar.baz.bam#boo:foo=bar`\\  \\ :ansretval:`foo.bar.baz.bam#boo:bar.baz[123].bam[len(x)\
-      \ - 1]=bar`\\ \n\n\\ :ansretval:`bam.baz.foo#lookup:foo`\\  \\ :ansretval:`bam.baz.foo#lookup:bar.baz[123].bam[len(x)\
-      \ - 1]`\\ \n\n\\ :ansretval:`bam.baz.foo#lookup:foo=`\\  \\ :ansretval:`bam.baz.foo#lookup:bar.baz[123].bam[len(x)\
-      \ - 1]=`\\ \n\n\\ :ansretval:`bam.baz.foo#lookup:foo=bar`\\  \\ :ansretval:`bam.baz.foo#lookup:bar.baz[123].bam[len(x)\
-      \ - 1]=bar`\\ \n\n\\ :ansretval:`foo`\\  \\ :ansretval:`bar.baz[123].bam[len(x)\
-      \ - 1]`\\ \n\n\\ :ansretval:`foo=`\\  \\ :ansretval:`bar.baz[123].bam[len(x)\
-      \ - 1]=`\\ \n\n\\ :ansretval:`foo=bar`\\  \\ :ansretval:`bar.baz[123].bam[len(x)\
-      \ - 1]=bar`\\ "
+    rst: |-
+      :ansretval:`foo.bar.baz.bam#boo:foo` :ansretval:`foo.bar.baz.bam#boo:bar.baz[123].bam[len(x) - 1]`
+
+      :ansretval:`foo.bar.baz.bam#boo:foo=` :ansretval:`foo.bar.baz.bam#boo:bar.baz[123].bam[len(x) - 1]=`
+
+      :ansretval:`foo.bar.baz.bam#boo:foo=bar` :ansretval:`foo.bar.baz.bam#boo:bar.baz[123].bam[len(x) - 1]=bar`
+
+      :ansretval:`bam.baz.foo#lookup:foo` :ansretval:`bam.baz.foo#lookup:bar.baz[123].bam[len(x) - 1]`
+
+      :ansretval:`bam.baz.foo#lookup:foo=` :ansretval:`bam.baz.foo#lookup:bar.baz[123].bam[len(x) - 1]=`
+
+      :ansretval:`bam.baz.foo#lookup:foo=bar` :ansretval:`bam.baz.foo#lookup:bar.baz[123].bam[len(x) - 1]=bar`
+
+      :ansretval:`foo` :ansretval:`bar.baz[123].bam[len(x) - 1]`
+
+      :ansretval:`foo=` :ansretval:`bar.baz[123].bam[len(x) - 1]=`
+
+      :ansretval:`foo=bar` :ansretval:`bar.baz[123].bam[len(x) - 1]=bar`
     parse_opts:
       currentPlugin:
         fqcn: foo.bar.baz.bam
@@ -1114,27 +1173,24 @@ test_vectors:
       `foo=' `bar.baz[123].bam[len(x) - 1]='
 
       `foo=bar' `bar.baz[123].bam[len(x) - 1]=bar'
-    rst_plain: "\\ :literal:`foo` (of boo plugin :ref:`foo.bar.baz.bam <ansible_collections.foo.bar.baz.bam_boo>`)\\\
-      \  \\ :literal:`bar.baz[123].bam[len(x) - 1]` (of boo plugin :ref:`foo.bar.baz.bam\
-      \ <ansible_collections.foo.bar.baz.bam_boo>`)\\ \n\n\\ :literal:`foo=` (of boo\
-      \ plugin :ref:`foo.bar.baz.bam <ansible_collections.foo.bar.baz.bam_boo>`)\\\
-      \  \\ :literal:`bar.baz[123].bam[len(x) - 1]=` (of boo plugin :ref:`foo.bar.baz.bam\
-      \ <ansible_collections.foo.bar.baz.bam_boo>`)\\ \n\n\\ :literal:`foo=bar` (of\
-      \ boo plugin :ref:`foo.bar.baz.bam <ansible_collections.foo.bar.baz.bam_boo>`)\\\
-      \  \\ :literal:`bar.baz[123].bam[len(x) - 1]=bar` (of boo plugin :ref:`foo.bar.baz.bam\
-      \ <ansible_collections.foo.bar.baz.bam_boo>`)\\ \n\n\\ :literal:`foo` (of lookup\
-      \ plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)\\  \\\
-      \ :literal:`bar.baz[123].bam[len(x) - 1]` (of lookup plugin :ref:`bam.baz.foo\
-      \ <ansible_collections.bam.baz.foo_lookup>`)\\ \n\n\\ :literal:`foo=` (of lookup\
-      \ plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)\\  \\\
-      \ :literal:`bar.baz[123].bam[len(x) - 1]=` (of lookup plugin :ref:`bam.baz.foo\
-      \ <ansible_collections.bam.baz.foo_lookup>`)\\ \n\n\\ :literal:`foo=bar` (of\
-      \ lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)\\\
-      \  \\ :literal:`bar.baz[123].bam[len(x) - 1]=bar` (of lookup plugin :ref:`bam.baz.foo\
-      \ <ansible_collections.bam.baz.foo_lookup>`)\\ \n\n\\ :literal:`foo`\\  \\ :literal:`bar.baz[123].bam[len(x)\
-      \ - 1]`\\ \n\n\\ :literal:`foo=`\\  \\ :literal:`bar.baz[123].bam[len(x) - 1]=`\\\
-      \ \n\n\\ :literal:`foo=bar`\\  \\ :literal:`bar.baz[123].bam[len(x) - 1]=bar`\\\
-      \ "
+    rst_plain: |-
+      :literal:`foo` (of boo plugin :ref:`foo.bar.baz.bam <ansible_collections.foo.bar.baz.bam_boo>`) :literal:`bar.baz[123].bam[len(x) - 1]` (of boo plugin :ref:`foo.bar.baz.bam <ansible_collections.foo.bar.baz.bam_boo>`)
+
+      :literal:`foo=` (of boo plugin :ref:`foo.bar.baz.bam <ansible_collections.foo.bar.baz.bam_boo>`) :literal:`bar.baz[123].bam[len(x) - 1]=` (of boo plugin :ref:`foo.bar.baz.bam <ansible_collections.foo.bar.baz.bam_boo>`)
+
+      :literal:`foo=bar` (of boo plugin :ref:`foo.bar.baz.bam <ansible_collections.foo.bar.baz.bam_boo>`) :literal:`bar.baz[123].bam[len(x) - 1]=bar` (of boo plugin :ref:`foo.bar.baz.bam <ansible_collections.foo.bar.baz.bam_boo>`)
+
+      :literal:`foo` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`) :literal:`bar.baz[123].bam[len(x) - 1]` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)
+
+      :literal:`foo=` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`) :literal:`bar.baz[123].bam[len(x) - 1]=` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)
+
+      :literal:`foo=bar` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`) :literal:`bar.baz[123].bam[len(x) - 1]=bar` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)
+
+      :literal:`foo` :literal:`bar.baz[123].bam[len(x) - 1]`
+
+      :literal:`foo=` :literal:`bar.baz[123].bam[len(x) - 1]=`
+
+      :literal:`foo=bar` :literal:`bar.baz[123].bam[len(x) - 1]=bar`
   return_value_no_current_plugin_w_links:
     source:
       - RV(foo) RV(bar.baz[123].bam[len(x\) - 1])
@@ -1175,16 +1231,24 @@ test_vectors:
       <code>foo\=bar</code> <code>bar\.baz\[123\]\.bam\[len\(x\) \- 1\]\=bar</code>
     md_opts:
       pluginOptionLikeLinkTemplate: https://docs.ansible.com/ansible/devel/collections/{plugin_fqcn_slashes}_{plugin_type}.html#{what}{entrypoint_with_leading_dash}-{name_slashes}
-    rst: "\\ :ansretval:`foo`\\  \\ :ansretval:`bar.baz[123].bam[len(x) - 1]`\\ \n\
-      \n\\ :ansretval:`foo=`\\  \\ :ansretval:`bar.baz[123].bam[len(x) - 1]=`\\ \n\
-      \n\\ :ansretval:`foo=bar`\\  \\ :ansretval:`bar.baz[123].bam[len(x) - 1]=bar`\\\
-      \ \n\n\\ :ansretval:`bam.baz.foo#lookup:foo`\\  \\ :ansretval:`bam.baz.foo#lookup:bar.baz[123].bam[len(x)\
-      \ - 1]`\\ \n\n\\ :ansretval:`bam.baz.foo#lookup:foo=`\\  \\ :ansretval:`bam.baz.foo#lookup:bar.baz[123].bam[len(x)\
-      \ - 1]=`\\ \n\n\\ :ansretval:`bam.baz.foo#lookup:foo=bar`\\  \\ :ansretval:`bam.baz.foo#lookup:bar.baz[123].bam[len(x)\
-      \ - 1]=bar`\\ \n\n\\ :ansretval:`foo`\\  \\ :ansretval:`bar.baz[123].bam[len(x)\
-      \ - 1]`\\ \n\n\\ :ansretval:`foo=`\\  \\ :ansretval:`bar.baz[123].bam[len(x)\
-      \ - 1]=`\\ \n\n\\ :ansretval:`foo=bar`\\  \\ :ansretval:`bar.baz[123].bam[len(x)\
-      \ - 1]=bar`\\ "
+    rst: |-
+      :ansretval:`foo` :ansretval:`bar.baz[123].bam[len(x) - 1]`
+
+      :ansretval:`foo=` :ansretval:`bar.baz[123].bam[len(x) - 1]=`
+
+      :ansretval:`foo=bar` :ansretval:`bar.baz[123].bam[len(x) - 1]=bar`
+
+      :ansretval:`bam.baz.foo#lookup:foo` :ansretval:`bam.baz.foo#lookup:bar.baz[123].bam[len(x) - 1]`
+
+      :ansretval:`bam.baz.foo#lookup:foo=` :ansretval:`bam.baz.foo#lookup:bar.baz[123].bam[len(x) - 1]=`
+
+      :ansretval:`bam.baz.foo#lookup:foo=bar` :ansretval:`bam.baz.foo#lookup:bar.baz[123].bam[len(x) - 1]=bar`
+
+      :ansretval:`foo` :ansretval:`bar.baz[123].bam[len(x) - 1]`
+
+      :ansretval:`foo=` :ansretval:`bar.baz[123].bam[len(x) - 1]=`
+
+      :ansretval:`foo=bar` :ansretval:`bar.baz[123].bam[len(x) - 1]=bar`
     ansible_doc_text: |-
       `foo' `bar.baz[123].bam[len(x) - 1]'
 
@@ -1203,21 +1267,24 @@ test_vectors:
       `foo=' `bar.baz[123].bam[len(x) - 1]='
 
       `foo=bar' `bar.baz[123].bam[len(x) - 1]=bar'
-    rst_plain: "\\ :literal:`foo`\\  \\ :literal:`bar.baz[123].bam[len(x) - 1]`\\\
-      \ \n\n\\ :literal:`foo=`\\  \\ :literal:`bar.baz[123].bam[len(x) - 1]=`\\ \n\
-      \n\\ :literal:`foo=bar`\\  \\ :literal:`bar.baz[123].bam[len(x) - 1]=bar`\\\
-      \ \n\n\\ :literal:`foo` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)\\\
-      \  \\ :literal:`bar.baz[123].bam[len(x) - 1]` (of lookup plugin :ref:`bam.baz.foo\
-      \ <ansible_collections.bam.baz.foo_lookup>`)\\ \n\n\\ :literal:`foo=` (of lookup\
-      \ plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)\\  \\\
-      \ :literal:`bar.baz[123].bam[len(x) - 1]=` (of lookup plugin :ref:`bam.baz.foo\
-      \ <ansible_collections.bam.baz.foo_lookup>`)\\ \n\n\\ :literal:`foo=bar` (of\
-      \ lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)\\\
-      \  \\ :literal:`bar.baz[123].bam[len(x) - 1]=bar` (of lookup plugin :ref:`bam.baz.foo\
-      \ <ansible_collections.bam.baz.foo_lookup>`)\\ \n\n\\ :literal:`foo`\\  \\ :literal:`bar.baz[123].bam[len(x)\
-      \ - 1]`\\ \n\n\\ :literal:`foo=`\\  \\ :literal:`bar.baz[123].bam[len(x) - 1]=`\\\
-      \ \n\n\\ :literal:`foo=bar`\\  \\ :literal:`bar.baz[123].bam[len(x) - 1]=bar`\\\
-      \ "
+    rst_plain: |-
+      :literal:`foo` :literal:`bar.baz[123].bam[len(x) - 1]`
+
+      :literal:`foo=` :literal:`bar.baz[123].bam[len(x) - 1]=`
+
+      :literal:`foo=bar` :literal:`bar.baz[123].bam[len(x) - 1]=bar`
+
+      :literal:`foo` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`) :literal:`bar.baz[123].bam[len(x) - 1]` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)
+
+      :literal:`foo=` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`) :literal:`bar.baz[123].bam[len(x) - 1]=` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)
+
+      :literal:`foo=bar` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`) :literal:`bar.baz[123].bam[len(x) - 1]=bar` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)
+
+      :literal:`foo` :literal:`bar.baz[123].bam[len(x) - 1]`
+
+      :literal:`foo=` :literal:`bar.baz[123].bam[len(x) - 1]=`
+
+      :literal:`foo=bar` :literal:`bar.baz[123].bam[len(x) - 1]=bar`
   return_value_current_plugin_w_links:
     source:
       - RV(foo) RV(bar.baz[123].bam[len(x\) - 1])
@@ -1258,16 +1325,24 @@ test_vectors:
       <code>foo\=bar</code> <code>bar\.baz\[123\]\.bam\[len\(x\) \- 1\]\=bar</code>
     md_opts:
       pluginOptionLikeLinkTemplate: https://docs.ansible.com/ansible/devel/collections/{plugin_fqcn_slashes}_{plugin_type}.html#{what}{entrypoint_with_leading_dash}-{name_slashes}
-    rst: "\\ :ansretval:`foo.bar.baz.bam#boo:foo`\\  \\ :ansretval:`foo.bar.baz.bam#boo:bar.baz[123].bam[len(x)\
-      \ - 1]`\\ \n\n\\ :ansretval:`foo.bar.baz.bam#boo:foo=`\\  \\ :ansretval:`foo.bar.baz.bam#boo:bar.baz[123].bam[len(x)\
-      \ - 1]=`\\ \n\n\\ :ansretval:`foo.bar.baz.bam#boo:foo=bar`\\  \\ :ansretval:`foo.bar.baz.bam#boo:bar.baz[123].bam[len(x)\
-      \ - 1]=bar`\\ \n\n\\ :ansretval:`bam.baz.foo#lookup:foo`\\  \\ :ansretval:`bam.baz.foo#lookup:bar.baz[123].bam[len(x)\
-      \ - 1]`\\ \n\n\\ :ansretval:`bam.baz.foo#lookup:foo=`\\  \\ :ansretval:`bam.baz.foo#lookup:bar.baz[123].bam[len(x)\
-      \ - 1]=`\\ \n\n\\ :ansretval:`bam.baz.foo#lookup:foo=bar`\\  \\ :ansretval:`bam.baz.foo#lookup:bar.baz[123].bam[len(x)\
-      \ - 1]=bar`\\ \n\n\\ :ansretval:`foo`\\  \\ :ansretval:`bar.baz[123].bam[len(x)\
-      \ - 1]`\\ \n\n\\ :ansretval:`foo=`\\  \\ :ansretval:`bar.baz[123].bam[len(x)\
-      \ - 1]=`\\ \n\n\\ :ansretval:`foo=bar`\\  \\ :ansretval:`bar.baz[123].bam[len(x)\
-      \ - 1]=bar`\\ "
+    rst: |-
+      :ansretval:`foo.bar.baz.bam#boo:foo` :ansretval:`foo.bar.baz.bam#boo:bar.baz[123].bam[len(x) - 1]`
+
+      :ansretval:`foo.bar.baz.bam#boo:foo=` :ansretval:`foo.bar.baz.bam#boo:bar.baz[123].bam[len(x) - 1]=`
+
+      :ansretval:`foo.bar.baz.bam#boo:foo=bar` :ansretval:`foo.bar.baz.bam#boo:bar.baz[123].bam[len(x) - 1]=bar`
+
+      :ansretval:`bam.baz.foo#lookup:foo` :ansretval:`bam.baz.foo#lookup:bar.baz[123].bam[len(x) - 1]`
+
+      :ansretval:`bam.baz.foo#lookup:foo=` :ansretval:`bam.baz.foo#lookup:bar.baz[123].bam[len(x) - 1]=`
+
+      :ansretval:`bam.baz.foo#lookup:foo=bar` :ansretval:`bam.baz.foo#lookup:bar.baz[123].bam[len(x) - 1]=bar`
+
+      :ansretval:`foo` :ansretval:`bar.baz[123].bam[len(x) - 1]`
+
+      :ansretval:`foo=` :ansretval:`bar.baz[123].bam[len(x) - 1]=`
+
+      :ansretval:`foo=bar` :ansretval:`bar.baz[123].bam[len(x) - 1]=bar`
     parse_opts:
       currentPlugin:
         fqcn: foo.bar.baz.bam
@@ -1290,27 +1365,24 @@ test_vectors:
       `foo=' `bar.baz[123].bam[len(x) - 1]='
 
       `foo=bar' `bar.baz[123].bam[len(x) - 1]=bar'
-    rst_plain: "\\ :literal:`foo` (of boo plugin :ref:`foo.bar.baz.bam <ansible_collections.foo.bar.baz.bam_boo>`)\\\
-      \  \\ :literal:`bar.baz[123].bam[len(x) - 1]` (of boo plugin :ref:`foo.bar.baz.bam\
-      \ <ansible_collections.foo.bar.baz.bam_boo>`)\\ \n\n\\ :literal:`foo=` (of boo\
-      \ plugin :ref:`foo.bar.baz.bam <ansible_collections.foo.bar.baz.bam_boo>`)\\\
-      \  \\ :literal:`bar.baz[123].bam[len(x) - 1]=` (of boo plugin :ref:`foo.bar.baz.bam\
-      \ <ansible_collections.foo.bar.baz.bam_boo>`)\\ \n\n\\ :literal:`foo=bar` (of\
-      \ boo plugin :ref:`foo.bar.baz.bam <ansible_collections.foo.bar.baz.bam_boo>`)\\\
-      \  \\ :literal:`bar.baz[123].bam[len(x) - 1]=bar` (of boo plugin :ref:`foo.bar.baz.bam\
-      \ <ansible_collections.foo.bar.baz.bam_boo>`)\\ \n\n\\ :literal:`foo` (of lookup\
-      \ plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)\\  \\\
-      \ :literal:`bar.baz[123].bam[len(x) - 1]` (of lookup plugin :ref:`bam.baz.foo\
-      \ <ansible_collections.bam.baz.foo_lookup>`)\\ \n\n\\ :literal:`foo=` (of lookup\
-      \ plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)\\  \\\
-      \ :literal:`bar.baz[123].bam[len(x) - 1]=` (of lookup plugin :ref:`bam.baz.foo\
-      \ <ansible_collections.bam.baz.foo_lookup>`)\\ \n\n\\ :literal:`foo=bar` (of\
-      \ lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)\\\
-      \  \\ :literal:`bar.baz[123].bam[len(x) - 1]=bar` (of lookup plugin :ref:`bam.baz.foo\
-      \ <ansible_collections.bam.baz.foo_lookup>`)\\ \n\n\\ :literal:`foo`\\  \\ :literal:`bar.baz[123].bam[len(x)\
-      \ - 1]`\\ \n\n\\ :literal:`foo=`\\  \\ :literal:`bar.baz[123].bam[len(x) - 1]=`\\\
-      \ \n\n\\ :literal:`foo=bar`\\  \\ :literal:`bar.baz[123].bam[len(x) - 1]=bar`\\\
-      \ "
+    rst_plain: |-
+      :literal:`foo` (of boo plugin :ref:`foo.bar.baz.bam <ansible_collections.foo.bar.baz.bam_boo>`) :literal:`bar.baz[123].bam[len(x) - 1]` (of boo plugin :ref:`foo.bar.baz.bam <ansible_collections.foo.bar.baz.bam_boo>`)
+
+      :literal:`foo=` (of boo plugin :ref:`foo.bar.baz.bam <ansible_collections.foo.bar.baz.bam_boo>`) :literal:`bar.baz[123].bam[len(x) - 1]=` (of boo plugin :ref:`foo.bar.baz.bam <ansible_collections.foo.bar.baz.bam_boo>`)
+
+      :literal:`foo=bar` (of boo plugin :ref:`foo.bar.baz.bam <ansible_collections.foo.bar.baz.bam_boo>`) :literal:`bar.baz[123].bam[len(x) - 1]=bar` (of boo plugin :ref:`foo.bar.baz.bam <ansible_collections.foo.bar.baz.bam_boo>`)
+
+      :literal:`foo` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`) :literal:`bar.baz[123].bam[len(x) - 1]` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)
+
+      :literal:`foo=` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`) :literal:`bar.baz[123].bam[len(x) - 1]=` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)
+
+      :literal:`foo=bar` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`) :literal:`bar.baz[123].bam[len(x) - 1]=bar` (of lookup plugin :ref:`bam.baz.foo <ansible_collections.bam.baz.foo_lookup>`)
+
+      :literal:`foo` :literal:`bar.baz[123].bam[len(x) - 1]`
+
+      :literal:`foo=` :literal:`bar.baz[123].bam[len(x) - 1]=`
+
+      :literal:`foo=bar` :literal:`bar.baz[123].bam[len(x) - 1]=bar`
   unhelpful_errors:
     source:
       - P(foo)
@@ -1328,24 +1400,24 @@ test_vectors:
       <b>ERROR while parsing</b>: While parsing C\(\) at index 1 of paragraph 2\: Cannot find closing \"\)\" after last parameter
 
       <b>ERROR while parsing</b>: While parsing R\(\) at index 1 of paragraph 3\: Cannot find closing \"\)\" after last parameter
-    rst: "\\ :strong:`ERROR while parsing`\\ : While parsing P() at index 1 of paragraph\
-      \ 1: Parameter \"foo\" is not of the form FQCN#type\\ \n\n\\ :strong:`ERROR\
-      \ while parsing`\\ : While parsing C() at index 1 of paragraph 2: Cannot find\
-      \ closing \")\" after last parameter\\ \n\n\\ :strong:`ERROR while parsing`\\\
-      \ : While parsing R() at index 1 of paragraph 3: Cannot find closing \")\" after\
-      \ last parameter\\ "
+    rst: |-
+      :strong:`ERROR while parsing`\ : While parsing P() at index 1 of paragraph 1: Parameter "foo" is not of the form FQCN#type
+
+      :strong:`ERROR while parsing`\ : While parsing C() at index 1 of paragraph 2: Cannot find closing ")" after last parameter
+
+      :strong:`ERROR while parsing`\ : While parsing R() at index 1 of paragraph 3: Cannot find closing ")" after last parameter
     ansible_doc_text: |-
       [[ERROR while parsing: While parsing P() at index 1 of paragraph 1: Parameter "foo" is not of the form FQCN#type]]
 
       [[ERROR while parsing: While parsing C() at index 1 of paragraph 2: Cannot find closing ")" after last parameter]]
 
       [[ERROR while parsing: While parsing R() at index 1 of paragraph 3: Cannot find closing ")" after last parameter]]
-    rst_plain: "\\ :strong:`ERROR while parsing`\\ : While parsing P() at index 1\
-      \ of paragraph 1: Parameter \"foo\" is not of the form FQCN#type\\ \n\n\\ :strong:`ERROR\
-      \ while parsing`\\ : While parsing C() at index 1 of paragraph 2: Cannot find\
-      \ closing \")\" after last parameter\\ \n\n\\ :strong:`ERROR while parsing`\\\
-      \ : While parsing R() at index 1 of paragraph 3: Cannot find closing \")\" after\
-      \ last parameter\\ "
+    rst_plain: |-
+      :strong:`ERROR while parsing`\ : While parsing P() at index 1 of paragraph 1: Parameter "foo" is not of the form FQCN#type
+
+      :strong:`ERROR while parsing`\ : While parsing C() at index 1 of paragraph 2: Cannot find closing ")" after last parameter
+
+      :strong:`ERROR while parsing`\ : While parsing R() at index 1 of paragraph 3: Cannot find closing ")" after last parameter
   helpful_errors:
     source:
       - P(foo)
@@ -1361,139 +1433,191 @@ test_vectors:
       <b>ERROR while parsing</b>: While parsing \"C\(foo\" at index 1 of paragraph 2\: Cannot find closing \"\)\" after last parameter
 
       <b>ERROR while parsing</b>: While parsing \"R\(foo\,bar\" at index 1 of paragraph 3\: Cannot find closing \"\)\" after last parameter
-    rst: "\\ :strong:`ERROR while parsing`\\ : While parsing \"P(foo)\" at index 1\
-      \ of paragraph 1: Parameter \"foo\" is not of the form FQCN#type\\ \n\n\\ :strong:`ERROR\
-      \ while parsing`\\ : While parsing \"C(foo\" at index 1 of paragraph 2: Cannot\
-      \ find closing \")\" after last parameter\\ \n\n\\ :strong:`ERROR while parsing`\\\
-      \ : While parsing \"R(foo,bar\" at index 1 of paragraph 3: Cannot find closing\
-      \ \")\" after last parameter\\ "
+    rst: |-
+      :strong:`ERROR while parsing`\ : While parsing "P(foo)" at index 1 of paragraph 1: Parameter "foo" is not of the form FQCN#type
+
+      :strong:`ERROR while parsing`\ : While parsing "C(foo" at index 1 of paragraph 2: Cannot find closing ")" after last parameter
+
+      :strong:`ERROR while parsing`\ : While parsing "R(foo,bar" at index 1 of paragraph 3: Cannot find closing ")" after last parameter
     ansible_doc_text: |-
       [[ERROR while parsing: While parsing "P(foo)" at index 1 of paragraph 1: Parameter "foo" is not of the form FQCN#type]]
 
       [[ERROR while parsing: While parsing "C(foo" at index 1 of paragraph 2: Cannot find closing ")" after last parameter]]
 
       [[ERROR while parsing: While parsing "R(foo,bar" at index 1 of paragraph 3: Cannot find closing ")" after last parameter]]
-    rst_plain: "\\ :strong:`ERROR while parsing`\\ : While parsing \"P(foo)\" at index\
-      \ 1 of paragraph 1: Parameter \"foo\" is not of the form FQCN#type\\ \n\n\\\
-      \ :strong:`ERROR while parsing`\\ : While parsing \"C(foo\" at index 1 of paragraph\
-      \ 2: Cannot find closing \")\" after last parameter\\ \n\n\\ :strong:`ERROR\
-      \ while parsing`\\ : While parsing \"R(foo,bar\" at index 1 of paragraph 3:\
-      \ Cannot find closing \")\" after last parameter\\ "
+    rst_plain: |-
+      :strong:`ERROR while parsing`\ : While parsing "P(foo)" at index 1 of paragraph 1: Parameter "foo" is not of the form FQCN#type
+
+      :strong:`ERROR while parsing`\ : While parsing "C(foo" at index 1 of paragraph 2: Cannot find closing ")" after last parameter
+
+      :strong:`ERROR while parsing`\ : While parsing "R(foo,bar" at index 1 of paragraph 3: Cannot find closing ")" after last parameter
   whitespace_ignore:
     source: "Foo  bar\tbaz \n   Welcome  to  \n\r\n\r white\tspace\nfun\n\n\n! B(foo\
-      \  \t bar\nbaz \r bam) \n C(foo  \t bar\nbaz \r bam) \n HORIZONTALLINE x M(f\xF6\
-      \xF8  \t b\nz \r m)\n \_\_I(\_\_)C(\_\_)B( \_\_ )E( \_\_ )"
+      \  \t bar\nbaz \r bam) \n C(foo  \t bar\nbaz \r bam) \n HORIZONTALLINE x M(föø\
+      \  \t b\nz \r m)\n   I(  )C(  )B(    )E(    )"
     parse_opts:
       whitespace: ignore
     html: "<p>Foo  bar\tbaz \n   Welcome  to  \n\r\n\r white\tspace\nfun\n\n\n! <b>foo\
       \  \t bar\nbaz \r bam</b> \n <code class='docutils literal notranslate'>foo\
       \  \t bar\nbaz \r bam</code> \n<hr/>x <span class=\"error\">ERROR while parsing:\
-      \ While parsing \"M(f\xF6\xF8  \\t b\\nz \\r m)\" at index 125: Module name\
-      \ \"f\xF6\xF8  \\t b\\nz \\r m\" is not a FQCN</span>\n \_\_<em>\_\_</em><code\
-      \ class='docutils literal notranslate'>\_\_</code><b> \_\_ </b><code class=\"\
-      xref std std-envvar literal notranslate\"> \_\_ </code></p>"
+      \ While parsing \"M(föø  \\t b\\nz \\r m)\" at index 125: Module name \"föø\
+      \  \\t b\\nz \\r m\" is not a FQCN</span>\n   <em>  </em><code class='docutils\
+      \ literal notranslate'>  </code><b>    </b><code class=\"xref std std-envvar\
+      \ literal notranslate\">    </code></p>"
     html_plain: "<p>Foo  bar\tbaz \n   Welcome  to  \n\r\n\r white\tspace\nfun\n\n\
       \n! <b>foo  \t bar\nbaz \r bam</b> \n <code>foo  \t bar\nbaz \r bam</code> \n\
-      <hr>x <span class=\"error\">ERROR while parsing: While parsing \"M(f\xF6\xF8\
-      \  \\t b\\nz \\r m)\" at index 125: Module name \"f\xF6\xF8  \\t b\\nz \\r m\"\
-      \ is not a FQCN</span>\n \_\_<em>\_\_</em><code>\_\_</code><b> \_\_ </b><code>\
-      \ \_\_ </code></p>"
-    md: "Foo  bar\tbaz \n   Welcome  to  \n\r\n\r white\tspace\nfun\n\n\n\\! <b>foo\
-      \  \t bar\nbaz \r bam</b> \n <code>foo  \t bar\nbaz \r bam</code> \n<hr>x <b>ERROR\
-      \ while parsing</b>: While parsing \\\"M\\(f\xF6\xF8  \\\\t b\\\\nz \\\\r m\\\
-      )\\\" at index 125\\: Module name \\\"f\xF6\xF8  \\\\t b\\\\nz \\\\r m\\\" is\
-      \ not a FQCN\n \_\_<em>\_\_</em><code>\_\_</code><b> \_\_ </b><code> \_\_ </code>"
-    rst: "Foo  bar\tbaz \n   Welcome  to  \n\r\n\r white\tspace\nfun\n\n\n! \\ :strong:`foo\
-      \  \t bar\nbaz \r bam`\\  \n \\ :literal:`foo  \t bar\nbaz \r bam`\\  \n\n\n\
-      .. raw:: html\n\n  <hr>\n\nx \\ :strong:`ERROR while parsing`\\ : While parsing\
-      \ \"M(f\xF6\xF8  \\\\t b\\\\nz \\\\r m)\" at index 125: Module name \"f\xF6\xF8\
-      \  \\\\t b\\\\nz \\\\r m\" is not a FQCN\\ \n \_\_\\ :emphasis:`\_\_`\\ \\ :literal:`\_\
-      \_`\\ \\ :strong:`\\  \_\_ \\ `\\ \\ :envvar:`\\  \_\_ \\ `\\ "
-    rst_plain: "Foo  bar\tbaz \n   Welcome  to  \n\r\n\r white\tspace\nfun\n\n\n!\
-      \ \\ :strong:`foo  \t bar\nbaz \r bam`\\  \n \\ :literal:`foo  \t bar\nbaz \r\
-      \ bam`\\  \n\n\n------------\n\nx \\ :strong:`ERROR while parsing`\\ : While\
-      \ parsing \"M(f\xF6\xF8  \\\\t b\\\\nz \\\\r m)\" at index 125: Module name\
-      \ \"f\xF6\xF8  \\\\t b\\\\nz \\\\r m\" is not a FQCN\\ \n \_\_\\ :emphasis:`\_\
-      \_`\\ \\ :literal:`\_\_`\\ \\ :strong:`\\  \_\_ \\ `\\ \\ :envvar:`\\  \_\_\
-      \ \\ `\\ "
+      <hr>x <span class=\"error\">ERROR while parsing: While parsing \"M(föø  \\t\
+      \ b\\nz \\r m)\" at index 125: Module name \"föø  \\t b\\nz \\r m\" is not a\
+      \ FQCN</span>\n   <em>  </em><code>  </code><b>    </b><code>    </code></p>"
+    md: |-
+      Foo  bar baz
+      Welcome  to
+      white space
+      fun
+      \! <b>foo    bar
+      baz
+      bam</b>
+      <code>foo    bar
+      baz
+      bam</code>
+      <hr>x <b>ERROR while parsing</b>: While parsing \"M\(föø  \\t b\\nz \\r m\)\" at index 125\: Module name \"föø  \\t b\\nz \\r m\" is not a FQCN
+      <em>  </em><code>  </code><b>    </b><code>    </code>
+    rst: |-
+      Foo  bar baz
+      Welcome  to
+      white space
+      fun
+      ! :strong:`foo    bar
+      baz
+      bam`
+      :literal:`foo    bar
+      baz
+      bam`
+
+      .. raw:: html
+
+        <hr>
+
+      x :strong:`ERROR while parsing`\ : While parsing "M(föø  \\t b\\nz \\r m)" at index 125: Module name "föø  \\t b\\nz \\r m" is not a FQCN
+      :emphasis:`\   \ `\ :literal:`\   \ `\ :strong:`\     \ `\ :envvar:`\     \ `
+    rst_plain: |-
+      Foo  bar baz
+      Welcome  to
+      white space
+      fun
+      ! :strong:`foo    bar
+      baz
+      bam`
+      :literal:`foo    bar
+      baz
+      bam`
+
+      ------------
+
+      x :strong:`ERROR while parsing`\ : While parsing "M(föø  \\t b\\nz \\r m)" at index 125: Module name "föø  \\t b\\nz \\r m" is not a FQCN
+      :emphasis:`\   \ `\ :literal:`\   \ `\ :strong:`\     \ `\ :envvar:`\     \ `
     ansible_doc_text: "Foo  bar\tbaz \n   Welcome  to  \n\r\n\r white\tspace\nfun\n\
       \n\n! *foo  \t bar\nbaz \r bam* \n `foo  \t bar\nbaz \r bam' \n\n-------------\n\
-      x [[ERROR while parsing: While parsing \"M(f\xF6\xF8  \\t b\\nz \\r m)\" at\
-      \ index 125: Module name \"f\xF6\xF8  \\t b\\nz \\r m\" is not a FQCN]]\n \_\
-      \_`\_\_'`\_\_'* \_\_ *` \_\_ '"
+      x [[ERROR while parsing: While parsing \"M(föø  \\t b\\nz \\r m)\" at index\
+      \ 125: Module name \"föø  \\t b\\nz \\r m\" is not a FQCN]]\n   `  '`  '*   \
+      \ *`    '"
   whitespace_strip:
     source: "Foo  bar\tbaz \n   Welcome  to  \n\r\n\r white\tspace\nfun\n\n\n! B(foo\
-      \  \t bar\nbaz \r bam) \n C(foo  \t bar\nbaz \r bam) \n HORIZONTALLINE x M(f\xF6\
-      \xF8  \t b\nz \r m)\n \_\_I(\_\_)C(\_\_)B( \_\_ )E( \_\_ )"
+      \  \t bar\nbaz \r bam) \n C(foo  \t bar\nbaz \r bam) \n HORIZONTALLINE x M(föø\
+      \  \t b\nz \r m)\n   I(  )C(  )B(    )E(    )"
     parse_opts:
       whitespace: strip
-    html: "<p>Foo bar baz Welcome to white space fun ! <b>foo bar baz bam</b> <code\
-      \ class='docutils literal notranslate'>foo    bar baz   bam</code> <hr/>x <span\
-      \ class=\"error\">ERROR while parsing: While parsing \"M(f\xF6\xF8  \\t b\\\
-      nz \\r m)\" at index 125: Module name \"f\xF6\xF8 b z m\" is not a FQCN</span>\
-      \ \_\_<em>\_\_</em><code class='docutils literal notranslate'>\_\_</code><b>\
-      \ \_\_ </b><code class=\"xref std std-envvar literal notranslate\"> \_\_ </code></p>"
-    html_plain: "<p>Foo bar baz Welcome to white space fun ! <b>foo bar baz bam</b>\
-      \ <code>foo    bar baz   bam</code> <hr>x <span class=\"error\">ERROR while\
-      \ parsing: While parsing \"M(f\xF6\xF8  \\t b\\nz \\r m)\" at index 125: Module\
-      \ name \"f\xF6\xF8 b z m\" is not a FQCN</span> \_\_<em>\_\_</em><code>\_\_\
-      </code><b> \_\_ </b><code> \_\_ </code></p>"
-    md: "Foo bar baz Welcome to white space fun \\! <b>foo bar baz bam</b> <code>foo\
-      \    bar baz   bam</code> <hr>x <b>ERROR while parsing</b>: While parsing \\\
-      \"M\\(f\xF6\xF8  \\\\t b\\\\nz \\\\r m\\)\\\" at index 125\\: Module name \\\
-      \"f\xF6\xF8 b z m\\\" is not a FQCN \_\_<em>\_\_</em><code>\_\_</code><b> \_\
-      \_ </b><code> \_\_ </code>"
-    rst: "Foo bar baz Welcome to white space fun ! \\ :strong:`foo bar baz bam`\\\
-      \  \\ :literal:`foo    bar baz   bam`\\  \n\n.. raw:: html\n\n  <hr>\n\nx \\\
-      \ :strong:`ERROR while parsing`\\ : While parsing \"M(f\xF6\xF8  \\\\t b\\\\\
-      nz \\\\r m)\" at index 125: Module name \"f\xF6\xF8 b z m\" is not a FQCN\\\
-      \  \_\_\\ :emphasis:`\_\_`\\ \\ :literal:`\_\_`\\ \\ :strong:`\\  \_\_ \\ `\\\
-      \ \\ :envvar:`\\  \_\_ \\ `\\ "
-    rst_plain: "Foo bar baz Welcome to white space fun ! \\ :strong:`foo bar baz bam`\\\
-      \  \\ :literal:`foo    bar baz   bam`\\  \n\n------------\n\nx \\ :strong:`ERROR\
-      \ while parsing`\\ : While parsing \"M(f\xF6\xF8  \\\\t b\\\\nz \\\\r m)\" at\
-      \ index 125: Module name \"f\xF6\xF8 b z m\" is not a FQCN\\  \_\_\\ :emphasis:`\_\
-      \_`\\ \\ :literal:`\_\_`\\ \\ :strong:`\\  \_\_ \\ `\\ \\ :envvar:`\\  \_\_\
-      \ \\ `\\ "
+    html: |-
+      <p>Foo bar baz Welcome to white space fun ! <b>foo bar baz bam</b> <code class='docutils literal notranslate'>foo    bar baz   bam</code> <hr/>x <span class="error">ERROR while parsing: While parsing "M(föø  \t b\nz \r m)" at index 125: Module name "föø b z m" is not a FQCN</span>   <em>  </em><code class='docutils literal notranslate'>  </code><b>    </b><code class="xref std std-envvar literal notranslate">    </code></p>
+    html_plain: |-
+      <p>Foo bar baz Welcome to white space fun ! <b>foo bar baz bam</b> <code>foo    bar baz   bam</code> <hr>x <span class="error">ERROR while parsing: While parsing "M(föø  \t b\nz \r m)" at index 125: Module name "föø b z m" is not a FQCN</span>   <em>  </em><code>  </code><b>    </b><code>    </code></p>
+    md: |-
+      Foo bar baz Welcome to white space fun \! <b>foo bar baz bam</b> <code>foo    bar baz   bam</code> <hr>x <b>ERROR while parsing</b>: While parsing \"M\(föø  \\t b\\nz \\r m\)\" at index 125\: Module name \"föø b z m\" is not a FQCN   <em>  </em><code>  </code><b>    </b><code>    </code>
+    rst: |-
+      Foo bar baz Welcome to white space fun ! :strong:`foo bar baz bam` :literal:`foo    bar baz   bam`
+
+      .. raw:: html
+
+        <hr>
+
+      x :strong:`ERROR while parsing`\ : While parsing "M(föø  \\t b\\nz \\r m)" at index 125: Module name "föø b z m" is not a FQCN   \ :emphasis:`\   \ `\ :literal:`\   \ `\ :strong:`\     \ `\ :envvar:`\     \ `
+    rst_plain: |-
+      Foo bar baz Welcome to white space fun ! :strong:`foo bar baz bam` :literal:`foo    bar baz   bam`
+
+      ------------
+
+      x :strong:`ERROR while parsing`\ : While parsing "M(föø  \\t b\\nz \\r m)" at index 125: Module name "föø b z m" is not a FQCN   \ :emphasis:`\   \ `\ :literal:`\   \ `\ :strong:`\     \ `\ :envvar:`\     \ `
     ansible_doc_text: "Foo bar baz Welcome to white space fun ! *foo bar baz bam*\
       \ `foo    bar baz   bam' \n-------------\nx [[ERROR while parsing: While parsing\
-      \ \"M(f\xF6\xF8  \\t b\\nz \\r m)\" at index 125: Module name \"f\xF6\xF8 b\
-      \ z m\" is not a FQCN]] \_\_`\_\_'`\_\_'* \_\_ *` \_\_ '"
+      \ \"M(föø  \\t b\\nz \\r m)\" at index 125: Module name \"föø b z m\" is not\
+      \ a FQCN]]   `  '`  '*    *`    '"
   whitespace_keep_single_newlines:
     source: "Foo  bar\tbaz \n   Welcome  to  \n\r\n\r white\tspace\nfun\n\n\n! B(foo\
-      \  \t bar\nbaz \r bam) \n C(foo  \t bar\nbaz \r bam) \n HORIZONTALLINE x M(f\xF6\
-      \xF8  \t b\nz \r m)\n \_\_I(\_\_)C(\_\_)B( \_\_ )E( \_\_ )"
+      \  \t bar\nbaz \r bam) \n C(foo  \t bar\nbaz \r bam) \n HORIZONTALLINE x M(föø\
+      \  \t b\nz \r m)\n   I(  )C(  )B(    )E(    )"
     parse_opts:
       whitespace: keep_single_newlines
-    html: "<p>Foo bar baz\nWelcome to\nwhite space\nfun\n! <b>foo bar baz bam</b>\n\
-      <code class='docutils literal notranslate'>foo    bar baz   bam</code>\n<hr/>x\
-      \ <span class=\"error\">ERROR while parsing: While parsing \"M(f\xF6\xF8  \\\
-      t b\\nz \\r m)\" at index 125: Module name \"f\xF6\xF8 b z m\" is not a FQCN</span>\n\
-      \_\_<em>\_\_</em><code class='docutils literal notranslate'>\_\_</code><b> \_\
-      \_ </b><code class=\"xref std std-envvar literal notranslate\"> \_\_ </code></p>"
-    html_plain: "<p>Foo bar baz\nWelcome to\nwhite space\nfun\n! <b>foo bar baz bam</b>\n\
-      <code>foo    bar baz   bam</code>\n<hr>x <span class=\"error\">ERROR while parsing:\
-      \ While parsing \"M(f\xF6\xF8  \\t b\\nz \\r m)\" at index 125: Module name\
-      \ \"f\xF6\xF8 b z m\" is not a FQCN</span>\n\_\_<em>\_\_</em><code>\_\_</code><b>\
-      \ \_\_ </b><code> \_\_ </code></p>"
-    md: "Foo bar baz\nWelcome to\nwhite space\nfun\n\\! <b>foo bar baz bam</b>\n<code>foo\
-      \    bar baz   bam</code>\n<hr>x <b>ERROR while parsing</b>: While parsing \\\
-      \"M\\(f\xF6\xF8  \\\\t b\\\\nz \\\\r m\\)\\\" at index 125\\: Module name \\\
-      \"f\xF6\xF8 b z m\\\" is not a FQCN\n\_\_<em>\_\_</em><code>\_\_</code><b> \_\
-      \_ </b><code> \_\_ </code>"
-    rst: "Foo bar baz\nWelcome to\nwhite space\nfun\n! \\ :strong:`foo bar baz bam`\\\
-      \ \n\\ :literal:`foo    bar baz   bam`\\ \n\n\n.. raw:: html\n\n  <hr>\n\nx\
-      \ \\ :strong:`ERROR while parsing`\\ : While parsing \"M(f\xF6\xF8  \\\\t b\\\
-      \\nz \\\\r m)\" at index 125: Module name \"f\xF6\xF8 b z m\" is not a FQCN\\\
-      \ \n\_\_\\ :emphasis:`\_\_`\\ \\ :literal:`\_\_`\\ \\ :strong:`\\  \_\_ \\ `\\\
-      \ \\ :envvar:`\\  \_\_ \\ `\\ "
-    rst_plain: "Foo bar baz\nWelcome to\nwhite space\nfun\n! \\ :strong:`foo bar baz\
-      \ bam`\\ \n\\ :literal:`foo    bar baz   bam`\\ \n\n\n------------\n\nx \\ :strong:`ERROR\
-      \ while parsing`\\ : While parsing \"M(f\xF6\xF8  \\\\t b\\\\nz \\\\r m)\" at\
-      \ index 125: Module name \"f\xF6\xF8 b z m\" is not a FQCN\\ \n\_\_\\ :emphasis:`\_\
-      \_`\\ \\ :literal:`\_\_`\\ \\ :strong:`\\  \_\_ \\ `\\ \\ :envvar:`\\  \_\_\
-      \ \\ `\\ "
-    ansible_doc_text: "Foo bar baz\nWelcome to\nwhite space\nfun\n! *foo bar baz bam*\n\
-      `foo    bar baz   bam'\n\n-------------\nx [[ERROR while parsing: While parsing\
-      \ \"M(f\xF6\xF8  \\t b\\nz \\r m)\" at index 125: Module name \"f\xF6\xF8 b\
-      \ z m\" is not a FQCN]]\n\_\_`\_\_'`\_\_'* \_\_ *` \_\_ '"
+    html: |-
+      <p>Foo bar baz
+      Welcome to
+      white space
+      fun
+      ! <b>foo bar baz bam</b>
+      <code class='docutils literal notranslate'>foo    bar baz   bam</code>
+      <hr/>x <span class="error">ERROR while parsing: While parsing "M(föø  \t b\nz \r m)" at index 125: Module name "föø b z m" is not a FQCN</span>
+        <em>  </em><code class='docutils literal notranslate'>  </code><b>    </b><code class="xref std std-envvar literal notranslate">    </code></p>
+    html_plain: |-
+      <p>Foo bar baz
+      Welcome to
+      white space
+      fun
+      ! <b>foo bar baz bam</b>
+      <code>foo    bar baz   bam</code>
+      <hr>x <span class="error">ERROR while parsing: While parsing "M(föø  \t b\nz \r m)" at index 125: Module name "föø b z m" is not a FQCN</span>
+        <em>  </em><code>  </code><b>    </b><code>    </code></p>
+    md: |-
+      Foo bar baz
+      Welcome to
+      white space
+      fun
+      \! <b>foo bar baz bam</b>
+      <code>foo    bar baz   bam</code>
+      <hr>x <b>ERROR while parsing</b>: While parsing \"M\(föø  \\t b\\nz \\r m\)\" at index 125\: Module name \"föø b z m\" is not a FQCN
+      <em>  </em><code>  </code><b>    </b><code>    </code>
+    rst: |-
+      Foo bar baz
+      Welcome to
+      white space
+      fun
+      ! :strong:`foo bar baz bam`
+      :literal:`foo    bar baz   bam`
+
+      .. raw:: html
+
+        <hr>
+
+      x :strong:`ERROR while parsing`\ : While parsing "M(föø  \\t b\\nz \\r m)" at index 125: Module name "föø b z m" is not a FQCN
+      :emphasis:`\   \ `\ :literal:`\   \ `\ :strong:`\     \ `\ :envvar:`\     \ `
+    rst_plain: |-
+      Foo bar baz
+      Welcome to
+      white space
+      fun
+      ! :strong:`foo bar baz bam`
+      :literal:`foo    bar baz   bam`
+
+      ------------
+
+      x :strong:`ERROR while parsing`\ : While parsing "M(föø  \\t b\\nz \\r m)" at index 125: Module name "föø b z m" is not a FQCN
+      :emphasis:`\   \ `\ :literal:`\   \ `\ :strong:`\     \ `\ :envvar:`\     \ `
+    ansible_doc_text: |-
+      Foo bar baz
+      Welcome to
+      white space
+      fun
+      ! *foo bar baz bam*
+      `foo    bar baz   bam'
+
+      -------------
+      x [[ERROR while parsing: While parsing "M(föø  \t b\nz \r m)" at index 125: Module name "föø b z m" is not a FQCN]]
+        `  '`  '*    *`    '


### PR DESCRIPTION
Basically https://github.com/ansible-community/antsibull-docs-parser/pull/56 in TypeScript.